### PR TITLE
Fix: Task: Task always been created regardless of the status of the deal

### DIFF
--- a/command/deal.go
+++ b/command/deal.go
@@ -215,7 +215,6 @@ func (cmdDeal *CmdDeal) sendDeals2Miner(taskName string, outputDir string, fileD
 
 			dealCid, err := lotusClient.LotusClientStartDeal(&dealConfig)
 			if dealCid == nil {
-				continue
 				dealCid = new(string)
 			}
 			deal := &libmodel.DealInfo{


### PR DESCRIPTION
When a deal in the task fails, update the dealCid to `` and append it to the task.