### PR TITLE
Release v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,482 +1,360 @@
-# Swan Client Tool Guide
+# Swan-Client Tool Guide
 [![Made by FilSwan](https://img.shields.io/badge/made%20by-FilSwan-green.svg)](https://www.filswan.com/)
 [![Chat on discord](https://img.shields.io/badge/join%20-discord-brightgreen.svg)](https://discord.com/invite/KKGhy8ZqzK)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 
-- Join us on our [public discord channel](https://discord.com/invite/KKGhy8ZqzK) for news, discussions, and status updates. 
-- [Check out our medium](https://filswan.medium.com) for the latest posts and announcements.
+
+Swan-client is an important Web3 toolkit. It provides different tools to help users connect to the web3 world. It includes the following features:
+
+ - Filecoin Deal Sender 
+ - Blockchain RPC Service (supported by Pocket Network)
 
 ## Table of Contents
-- [Functions](#Functions)
-- [Concepts](#Concepts)
-- [Prerequisites](#Prerequisites)
-- [Installation](#Installation)
-- [After Installation](#After-Installation)
-- [Configuration](#Configuration)
-- [Flowcharts](#Flowcharts)
-- [Create Car Files](#Create-Car-Files)
-- [Upload Car Files](#Upload-Car-Files)
-- [Create A Task](#Create-A-Task)
-- [Send Deals](#Send-Deals)
+- [1. Filecoin Deal Sender](#1-Filecoin-Deal-Sender)
+	- [1.1 Installation](#11-Installation)
+		- [From Prebuilt Package](#From-Prebuilt-Package)
+		- [From Source Code](#From-Source-Code)
+	- [1.2 Configuration](#12-Configuration)
+	- [1.3 Generate CAR Files](#13-Genarate-CAR-Files)
+		- [Graphsplit](#Graphsplit)
+		- [Lotus API](#Lotus-API)
+		- [IPFS API](#IPFS-API)
+		- [ipfs-car](#ipfs-car)
+	- [1.4 Upload CAR Files to IPFS](#14-Upload-CAR-Files-to-IPFS)
+	- [1.5 Create A Task](#15-Create-A-Task)
+		- [Private Task](#Private-Task)
+		- [Auto-bid Task](#Auto-bid-Task)
+		- [Manual-bid Task](#Manual-bid-Task)
+- [2. Blockchain RPC Service](#2-Blockchain-RPC-Service)
+	- [2.1 Deploy RPC Service](#21-Deploy-RPC-Service)
+	- [2.2 RPC Command Service](#22-RPC-Command-Service)
+## 1. Filecoin Deal Sender
+As a PiB level data onboarding tool for Filecoin Network, Swan-client can help users prepare data and send the data to storage providers in Filecoin network. The main features and steps are as follows:
+ - Generate CAR files from your source files by [graphsplit](#Graphsplit), [lotus](#Lotus-API), [IPFS](#IPFS-API) or [ipfs-car](#ipfs-car).
+ - Upload the CAR files to IPFS server and generate metadata file(JSON and CSV) for sending offline-deals. 
+ - Propose offline-deals based on the metadata file.
+ - Generate a final metadata file for storage providers to import deals.
+ - Create tasks and offline-deals on [Swan Platform](https://console.filswan.com/#/dashboard).
 
-## Functions
-* Generate Car files from your source files by Lotus, Graph-split or Ipfs.
-* Generate metadata e.g. Car file URI, start epoch, etc. and save them to a metadata JSON file.
-* Propose deals based on the metadata JSON file.
-* Generate a final JSON file containing deal CIDs and storage provider ids for storage providers to import deals.
-* Create tasks and offline deals on Swan Platform.
-* Send deals automatically to auto-bid storage providers.
+ 	**(Storage Providers can automatically import the deals by [Swan-Provider](https://github.com/filswan/go-swan-provider/tree/release-2.0.0))**
 
-## Concepts
-### Task
-- A task can contain one or multiple car files
-- Each car file can be sent to one or multiple miners
-- Methods to set miners for each car file in a task
-  * **Auto-bid**: `task.bid_mode=1`, Market Matcher will automatically allocate miners for each car file based on reputation system and the max copy number the task needs.
-  * **Manual-bid**: `task.bid_mode=0`, After bidders winning the bid, the task holder needs to propose the task to the winners.
-  * **None-bid**: `task.bid_mode=2`, It is required to propose each car file of a task to a list of specified miners.
-- Task Status:
-  * **Created**: After a task is created, its initial status is `Created` regardless of its type.
-  * **ActionRequired**: An autobid task, that is, `task.bid_mode=1`, has some information missing or invalid:
-    - MaxPrice: missing, or is not a valid number
-    - FastRetrieval: missing
-    - Type: missing, or not have valid value
+swan-client can help users send their data to storage providers by creating three different kind of tasks. The complete process from the source file to the storage provider is as follows:
+ - **Private Task**
+<img src="http://yuml.me/diagram/plain/activity/(start)->(Generate CAR Files)->(Upload CAR Files to IPFS)->(Create Private Task)->(end)" >
+ 
+- **Auto-bid Task**
+<img src="http://yuml.me/diagram/plain/activity/(start)->(Generate CAR Files)->(Upload CAR Files to IPFS)->(Create Auto-Bid Task)->(end)" >
 
-    :bell:You need to solve the above problems and change the task status to `Created` to participate next run of Market Matcher.
-### Car File
-- A car file is an independent unit to be sent to miners
-- Each car file can be sent to one or multiple miners
-- A car file is generated from source file(s) by Lotus, Graph-split, or Ipfs
-- The size of a car file can be up to 64GB.
-- Car File Status:
-  * **Created**: After a task is created, all its car files are in this status
-  * **ActionRequired**: An autobid task, that is, `task.bid_mode=1`, its car file has something missing or invalid:
-    - FileSize: missing, or is not a valid number
-    - FileUrl: missing
-    - StartEpoch: missing, or not have valid value, less than 0, or current epoch
-    - PayloadCid: missing
-    - PieceCid: missing
-  * **Assigned**: When its task is in auto-bid mode, that is, `task.bid_mode=1`, a car file has been assigned to a list of miners automatically by Market Matcher.
-### Offline Deal
-- An offline Deal means the transaction that a car file is sent to a miner
-- Offline Deal Status:
-  * **Assigned**: Only in auto-bid mode, that is `task.bid_mode=1`, when a miner is assigned to a car file, an offline deal record is created, and its status is `Assigned`.
-  * **Created**: For all the bid modes, after a car file is sent to a miner, the related deal status is `Created`.
-  * **...**: There are several other statuses, which are generated and used by Swan Provider and Swan Platform and they have the same meaning for tasks of all bid modes.
-- Every step of this tool will generate a JSON file which contains file(s) description like one of below:
-```json
-[
- {
-  "Uuid": "",
-  "SourceFileName": "srcFiles",
-  "SourceFilePath": "[source file path]",
-  "SourceFileMd5": "",
-  "SourceFileSize": 5231342,
-  "CarFileName": "bafybeidezzxpy3lrvzz2py56vasl7modkss4v56qwh67tzhetsn2qh3aem.car",
-  "CarFilePath": "[car file path]",
-  "CarFileMd5": "30fc76af655688cc6ef49bbb96ce938a",
-  "CarFileUrl": "[car file url]",
-  "CarFileSize": 5234921,
-  "PayloadCid": "bafybeidezzxpy3lrvzz2py56vasl7modkss4v56qwh67tzhetsn2qh3aem",
-  "PieceCid": "baga6ea4seaqfbtlhrfnzuhbmwnjw4a7ovtjijae32g25o56jcuidk2fdzrjgmoi",
-  "StartEpoch": null,
-  "SourceId": null,
-  "Deals": null
- }
-]
-```
-```json
-[
- {
-  "Uuid": "072f8d4a-b79e-42b7-9452-3b8d1d41c11c",
-  "SourceFileName": "",
-  "SourceFilePath": "",
-  "SourceFileMd5": "",
-  "SourceFileSize": 0,
-  "CarFileName": "",
-  "CarFilePath": "",
-  "CarFileMd5": "",
-  "CarFileUrl": "[car file url]",
-  "CarFileSize": 5234921,
-  "PayloadCid": "bafybeidezzxpy3lrvzz2py56vasl7modkss4v56qwh67tzhetsn2qh3aem",
-  "PieceCid": "baga6ea4seaqfbtlhrfnzuhbmwnjw4a7ovtjijae32g25o56jcuidk2fdzrjgmoi",
-  "StartEpoch": null,
-  "SourceId": 2,
-  "Deals": [
-   {
-    "DealCid": "bafyreih2feyqpckrsmjnwgkm44el45obi3em7cjh7udkq6jgp4flkce6ra",
-    "MinerFid": "t03354",
-    "StartEpoch": 575856
-   }
-  ]
- }
-]
-```
-- This JSON file generated in each step will be used in its next step and can be used to rebuild the graph in the future.
-- Uuid is generated for future index purpose.
+ - **Manual-bid Task**
+<img src="http://yuml.me/diagram/plain/activity/(start)->(Generate CAR Files)->(Upload CAR Files to IPFS)->(Create Manual-Bid Task)->(Send Deals)->(end)" >
 
-## Prerequisites
-- Lotus node
 
-### Ubuntu
-- install missing packages as required
-### Mac
-- install missing packages as required
-- hwloc, such as
-```shell
-brew install hwloc
-```
-- set path LIBRARY_PATH to point to hwloc, such as
-```shell
-export LIBRARY_PATH=/opt/homebrew/Cellar/hwloc/2.6.0/lib
-```
-## Installation
-### Option:one:  **Prebuilt package**: See [release assets](https://github.com/filswan/go-swan-client/releases)
+### 1.1 Installation
+#### **From Prebuilt Package**
+
+See [release assets](https://github.com/filswan/go-swan-client/releases)
 ```shell
 mkdir swan-client
 cd swan-client
-wget --no-check-certificate https://github.com/filswan/go-swan-client/releases/download/v2.0.0-rc1/install.sh
+wget --no-check-certificate https://github.com/filswan/go-swan-client/releases/download/v2.0.0/install.sh
 chmod +x install.sh
 ./install.sh
 ```
 
-### Option:two:  Source Code
+#### **From Source Code**
 :bell:**go 1.16+** is required
 ```shell
 git clone https://github.com/filswan/go-swan-client.git
 cd go-swan-client
-git checkout <release_branch>
+git checkout release-2.0.0
 ./build_from_source.sh
 ```
+After you install from option two, the binary file `swan-client` is under `./build` directory
 
-## After Installation
-- If you install from source code, the binary file `swan-client` is under `./build` directory, you need to switch to it.
-```shell
-cd build
-```
-- Before executing, you should check your configuration in `~/.swan/client/config.toml` to ensure it is right.
+### 1.2 Configuration
+Before creating a task, you should update your configuration in `~/.swan/client/config.toml` to ensure it is right.
 ```shell
 vi ~/.swan/client/config.toml
 ```
-
-## Configuration
-### [lotus]
-- **client_api_url**:  Url of lotus client web api, such as: `http://[ip]:[port]/rpc/v0`, generally the `[port]` is `1234`. See [Lotus API](https://docs.filecoin.io/reference/lotus-api/#features)
-- **client_access_token**:  Access token of lotus client web api. It should have admin access right. You can get it from your lotus node machine using command `lotus auth create-token --perm admin`. See [Obtaining Tokens](https://docs.filecoin.io/build/lotus/api-tokens/#obtaining-tokens)
-
-### [main]
-- **api_url**: Swan API address. For Swan production, it is `https://go-swan-server.filswan.com`. It can be ignored if `[sender].offline_mode=true`.
-- :bangbang:**api_key**: Your Swan API key. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
-- :bangbang:**access_token**: Your Swan API access token. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
-- :bangbang:**storage_server_type**: `ipfs server` or `web server`
-
-### [web-server]
-- **download_url_prefix**: Web server url prefix, such as: `https://[ip]:[port]/download`. Store car files for downloading by storage provider. Car file url will be `[download_url_prefix]/[filename]`
-### [ipfs-server]
-- **download_url_prefix**: Ipfs server url prefix, such as: `http://[ip]:[port]`. Store car files for downloading by storage provider. Car file url will be `[download_url_prefix]/ipfs/[file_hash]`
-- **upload_url_prefix**: Ipfs server url for uploading files, such as `http://[ip]:[port]`
-
-### [sender]
-- **bid_mode**: [0/1/2] Default 1, which is auto-bid mod and it means swan will automatically allocate storage provider for it, while 0 is manual-bid mode and it needs to be bidded manually by storage providers, and 2 means not need bid, but set miners when creating a task.
-- **offline_mode**: [true/false] Default false. When set to true, you will not be able to create a Swan task on filswan.com, but you can still generate Car Files, CSV and JSON files for sending deals.
-- **output_dir**: When you do not set -out-dir option in your command, it is used as the default output directory for saving generated car files, CSV and JSON files. You need have access right to this folder or to create it.
-- **verified_deal**: [true/false] Whether deals in this task are going to be sent as verified or not.
-- **fast_retrieval**: [true/false] Indicates that data should be available for fast retrieval or not.
-- **generate_md5**: [true/false] Whether to generate md5 for each car file and source file, note: this is a resource consuming action.
-- **skip_confirmation**: [true/false] Whether to skip manual confirmation of each deal before sending.
-- **wallet**:  Wallet used for sending offline deals
-- **max_price**: Max price willing to pay per GiB/epoch for offline deals
-- **start_epoch_hours**: Start_epoch for deals in hours from current time.
-- **expired_days**: Expected completion days for storage provider sealing data.
-- **gocar_file_size_limit**: Go car file size limit in bytes
-- **gocar_folder_based**: Generate car file based on whole folder, or on each file separately
-- **duration**: Expressed in epochs (30 seconds per epoch). Default value is 1512000, that is 525 days. Valid value range:[518400, 1540000].
-- **max_auto_bid_copy_number**: When in auto-bid mode, that is `bid_mode=1`, max number of miners a car file can be allocated by Market Matcher
-
-## Flowcharts
-
-### Option:one: Manual-bid Mode
-- **Conditions:** `[sender].bid_mode=0`, see [Configuration](#Configuration)
-<img src="http://yuml.me/diagram/plain/activity/(start)->(Create Car Files)->(Upload Car Files)->(Create Manual-Bid Task)->(Send Deals)->(end)" >
-
-- Only `Created` status exists for both task and car file
-
-
-### Option:two: Auto-bid Mode
-- **Conditions:** `[sender].bid_mode=1`, see [Configuration](#Configuration)
-<img src="http://yuml.me/diagram/plain/activity/(start)->(Create Car Files)->(Upload Car Files)->(Create Auto-Bid Task)->(Send Auto-Bid Deals)->(end)" >
-
-- If a task does not match auto-bid conditions, its status will be changed from `Created` to `Action Required`
-- If a car file does not match auto-bid conditions, its status will be changed from `Created` to `Action Required`
-- If both a car file and its task match auto-bid conditions
-  - Miners that match the task and car file requirements will be assigned to car files
-  - The max number of allocated miners depend on `max_auto_bid_copy_number`, see [Configuration](#Configuration)
-  - If there are miners allocated to a car file, its status will be changed to `Assigned` and task's status remains at `Created`
-  - If there is no miner meet the the car file's and its task's requirements, then their status remain at `Created`
-
-### Option:three: None-bid Mode
-- **Conditions:** `[sender].bid_mode=2`, see [Configuration](#Configuration)
-<img src="http://yuml.me/diagram/plain/activity/(start)->(Create Car Files)->(Upload Car Files)->(Create None-bid Task)->(end)" >
-
-- In this option, deal(s) will be sent when creating a task.
-
-- Only `Created` status exists for both task and car file
-
-## Create Car Files
-:bell: The input dir and out dir should only be absolute one.
-
-:bell: This step is necessary for tasks in all of the bid modes. You can choose one of the following 3 options.
-
-### Option:one: By Lotus
-:bell: This option will generate a car file for each file in source directory.
-```shell
-./swan-client car -input-dir [input_files_dir] -out-dir [car_files_output_dir]
 ```
-**Command parameters used in this step:**
-- -input-dir(Required): The directory where the source files reside in.
-- -out-dir(optional): Car files and metadata files will be generated into this directory. When omitted, use `[sender].output_dir` in [Configuration](#Configuration)
+[lotus]
+client_api_url = "http://[ip]:[port]/rpc/v0"   # Url of lotus client web api, generally the [port] is 1234
+client_access_token = ""                       # Access token of lotus client web api, it should have admin access right
 
-**Configurations used in this step:**
-- [lotus].client_api_url, see [Configuration](#Configuration)
-- [lotus].client_access_token, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [sender].generate_md5, when it is true, then generate md5 for source files and car files, see [Configuration](#Configuration)
+[main]
+api_url = "https://go-swan-server.filswan.com" # Swan API address. For Swan production, it is `https://go-swan-server.filswan.com`. It can be ignored if `[sender].offline_swan=true`
+api_key = "" # Swan API key. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
+access_token = ""                              # Swan API access token. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
 
-**Files generated after this step:**
-- car.json: contains information for both source files and car files, see [Offline Deal](#Offline-Deal)
-- [source-file-name].car: each source file has a related car file
+[ipfs_server]
+download_url_prefix = "http://[ip]:[port]"     # IPFS server url prefix. Store CAR files for downloading by storage provider. The downloading url will be `[download_url_prefix]/ipfs/[dataCID]`
+upload_url_prefix = "http://[ip]:[port]"       # IPFS server url for uploading files
 
-### Option:two: By Graphsplit
+[sender]
+offline_swan = false                           # Whether to create a task on [Swan Platform](https://console.filswan.com/#/dashboard), when set to true, only generate metadata for Storage Providers to import deals. 
+verified_deal = true                           # Whether deals in the task are going to be sent as verified or not
+fast_retrieval = true                          # Whether deals in the task are available for fast-retrieval or not
+skip_confirmation = false                      # Whether to skip manual confirmation of each deal before sending
+generate_md5 = false                           # Whether to generate md5 for each car file and source file(resource consuming)
+wallet = ""                                    # Wallet used for sending offline deals
+max_price = "0"                                # Max price willing to pay per GiB/epoch for offline deals
+start_epoch_hours = 96                         # Specify hours that the deal should after at (default 96 hours)
+expire_days = 4                                # Specify days that the deal will expire after (default 4 days) 
+duration = 1512000                             # How long the Storage Providers should store the data for, in blocks(30s/block), default 1512000.
+start_deal_time_interval = 500                 # The interval between two deals sent, default: 500ms
+```
+
+### 1.3 Generate CAR Files
+A CAR file is an independent unit to be sent to storage providers, swan-client provides four different ways to generate CAR files, and the CAR file will be imported to lotus.
+
+#### Graphsplit
 :bell: This option can split a file under source directory or the files in a whole directory to one or more car file(s) in output directory.
 ```shell
-./swan-client gocar -input-dir [input_files_dir] -out-dir [car_files_output_dir]
-```
-**Command parameters used in this step:**
-- -input-dir(Required): The directory where the source files reside in.
-- -out-dir(optional): Car files and metadata files will be generated into this directory. When omitted, use `[sender].output_dir` in [Configuration](#Configuration)
+./swan-client generate-car graphsplit car --input-dir [input_files_dir] --out-dir [car_files_output_dir]
 
-**Configurations used in this step:**
-- [lotus].client_api_url, see [Configuration](#Configuration)
-- [lotus].client_access_token, see [Configuration](#Configuration)
-- [sender].gocar_file_size_limit, see [Configuration](#Configuration)
-- [sender].gocar_folder_based, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [sender].generate_md5, when it is true, then generate md5 for source files and car files, see [Configuration](#Configuration)
+OPTIONS:
+   --input-dir value, -i value       directory where source file(s) is(are) in.
+   --out-dir value, -o value         directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                          whether to import CAR file to lotus (default: true)
+   --parallel value                  number goroutines run when building ipld nodes (default: 5)
+   --slice-size value, --size value  bytes of each piece (default: 17179869184)
+   --parent-path                     generate CAR file based on whole folder (default: true)
+```
 
 **Files generated after this step:**
-- manifest.csv: this is generated by `graphsplit api`
-- car.json: contains information for both source files and car files, see [Offline Deal](#Offline-Deal), generated from `manifest.csv`
-- [hash-value-of-file-part].car: if `gocar_folder_based=true`, the folder will have one or more car files, otherwize each a source file will have one or more related car file(s), according to its size and `[sender].gocar_file_size_limit`
+- `manifest.csv`: A metadata file generated by `graphsplit API`
+- `car.json`: contains information for both source files and CAR files
+- `car.csv`: contains information for both source files and CAR files
+- `[dataCID].car`: if `--parent-path=true` is set, the CAR files generated based on the whole directory, otherwize based on each file according to file size and `--slice-size`
 
-**Note:**
-- If source filesize is greater than `[sender].gocar_file_size_limit`, the source file information in the metadata files are for temporary source files, which are generated by `graphsplit api`, and after the car files are generated, those temporary source files will be deleted by `graphsplit api`. And in this condition, we do not create source file MD5 in the metadata files.
+Credits should be given to filedrive-team. More information can be found [here](https://github.com/filedrive-team/go-graphsplit)
 
-Credits should be given to filedrive-team. More information can be found in https://github.com/filedrive-team/go-graphsplit.
+#### Lotus API
+:bell: This option will generate a CAR file for each file in `--input-dir`.
 
-### Option:three: By Ipfs Web Api
-:bell: This option will merge files under source directory to one car file in output directory using ipfs web api.
+:bell: A running **Lotus** node is required.
 ```shell
-./swan-client ipfscar -input-dir [input_files_dir] -out-dir [car_file_output_dir]
-```
-**Command parameters used in this step:**
-- -input-dir(Required): The directory where the source files reside in.
-- -out-dir(optional): Car file and metadata files will be generated into this directory. When omitted, use `[sender].output_dir` in [Configuration](#Configuration)
+./swan-client generate-car lotus --input-dir [input_files_dir] --out-dir [car_files_output_dir]
 
-**Configurations used in this step:**
-- [lotus].client_api_url, see [Configuration](#Configuration)
-- [lotus].client_access_token, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [sender].generate_md5, when it is true, then generate md5 for source files and car files, see [Configuration](#Configuration)
-- [ipfs_server].upload_url_prefix, see [Configuration](#Configuration)
+OPTIONS:
+   --input-dir value, -i value  directory where source file(s) is(are) in.
+   --out-dir value, -o value    directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                     whether to import CAR file to lotus (default: true)
+```
 
 **Files generated after this step:**
-- car.json: contains information for car file, see [Offline Deal](#Offline-Deal)
-- [car-file-cid].car: the source file(s) will be merged into this car file
+- `car.json`: contains information for both source files and CAR files
+- `car.csv`: contains information for both source files and CAR files
+- `[source-file-name].car`: each source file has a related CAR file
 
-### Option:four: By ipfs-car Command
-:bell: ipfs-car command should be installed first using
-```shell
-sudo npm install -g ipfs-car
-```
-:bell: This option will merge files under source directory to one car file in output directory using ipfs-car command.
-```shell
-./swan-client ipfscmdcar -input-dir [input_files_dir] -out-dir [car_file_output_dir]
-```
-**Command parameters used in this step:**
-- -input-dir(Required): The directory where the source files reside in.
-- -out-dir(optional): Car file and metadata files will be generated into this directory. When omitted, use `[sender].output_dir` in [Configuration](#Configuration)
+#### IPFS API
+:bell: This option will merge files under source directory to one car file in output directory using IPFS API.
 
-**Configurations used in this step:**
-- [lotus].client_api_url, see [Configuration](#Configuration)
-- [lotus].client_access_token, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [sender].generate_md5, when it is true, then generate md5 for source files and car files, see [Configuration](#Configuration)
+:bell: A running **IPFS** node is required.
+
+```shell
+./swan-client generate-car ipfs --input-dir [input_files_dir] --out-dir [car_file_output_dir]
+
+OPTIONS:
+   --input-dir value, -i value  directory where source file(s) is(are) in.
+   --out-dir value, -o value    directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                     whether to import CAR file to lotus (default: true)
+```
+**Files generated after this step:**
+- `car.json`: contains information for CAR file
+- `car.csv`: contains information for CAR file
+- `[dataCID].car`: the source file(s) will be merged into this car file
+
+#### ipfs-car 
+:bell: `ipfs-car` pacakage is **required**: `sudo npm install -g ipfs-car`
+
+:bell: This option will merge files under source directory to one car file in output directory using `ipfs-car` command.
+```shell
+./swan-client generate-car ipfs-car --input-dir [input_files_dir] --out-dir [car_file_output_dir]
+
+OPTIONS:
+   --input-dir value, -i value  directory where source file(s) is(are) in.
+   --out-dir value, -o value    directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                     whether to import CAR file to lotus (default: true)
+```
 
 **Files generated after this step:**
-- car.json: contains information for car file, see [Offline Deal](#Offline-Deal)
-- [source-files-dir-name].car: the source file(s) will be merged into this car file
+- `car.json`: contains information for CAR file
+- `car.csv`: contains information for CAR file
+- `[source-files-dir-name].car`: the source file(s) will be merged into this CAR file
 
-## Upload Car Files
-:bell: It is required to upload car files to file server(s), either to web server or to ipfs server.
+### 1.4 Upload CAR Files to IPFS
+:bell:- `[ipfs_server].download_url_prefix` and `[ipfs_server].upload_url_prefix` are required to upload CAR files to IPFS server.
 
-### Option:one: To a web-server manually
-```shell
-no swan-client subcommand should be executed
-```
-**Configurations used in this step:**
-- [main].storage_server_type, it should be set to `web server`, see [Configuration](#Configuration)
-
-### Option:two: To a local ipfs server
 ```shell
 ./swan-client upload -input-dir [input_file_dir]
+
+OPTIONS:
+   --input-dir value, -i value  directory where source files are in.
+
 ```
-**Command parameters used in this step:**
-- -input-dir(Required): The directory where the car files and metadata files reside in. Metadata files will be used and updated here after car files uploaded.
-
-**Configurations used in this step:**
-- [main].storage_server_type, it should be set to `ipfs server`. See [Configuration](#Configuration)
-- [ipfs_server].download_url_prefix, see [Configuration](#Configuration)
-- [ipfs_server].upload_url_prefix, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-
 **Files updated after this step:**
-- car.json: car file url will be updated on the original one, see [Offline Deal](#Offline-Deal)
+- `car.json`: the `CarFileUrl` of CAR files will be updated
+- `car.csv`: the `CarFileUrl` of CAR files will be updated
 
-## Create A Task
-:bell: This step is necessary for tasks in all bid modes. You can choose one of the following 3 options.
+### 1.5 Create A Task
+You can create three different kind of task using the `car.json` or `car.csv` 
+#### Private Task
+You can directly send deals to miners by creating a  private task
 
-### Option:one: None-bid Mode
-- **Conditions:** `[sender].bid_mode=2`, see [Configuration](#Configuration)
 ```shell
-./swan-client task -input-dir [car_files_dir] -out-dir [output_files_dir] -miner [Storage_provider_ids] -dataset [curated_dataset] -description [description]
-```
-**Command parameters used in this step:**
-- -input-dir(Required): Input directory where the generated car files and metadata files reside in.
-- -out-dir(optional): Metadata files and swan task file will be generated to this directory. When ommitted, use default `[send].output_dir`, see [Configuration](#Configuration)
-- -miner(Required): Storage provider Ids you want to send car files to, miners separated by comma if there are more than one, e.g `f01276` or `t03354,f01276`
-- -dataset(optional): The curated dataset from which the car files are generated
-- -description(optional): Details to better describe the data and confine the task or anything the storage provider needs to be informed.
+./swan-client task --input-dir [json_or_csv_absolute_path] --out-dir [output_files_dir] --miners [storage_provider_id1,storage_provider_id2,...]
 
-**Configurations used in this step:**
-- [sender].bid_mode, see [Configuration](#Configuration)
-- [sender].verified_deal, see [Configuration](#Configuration)
-- [sender].offline_mode, see [Configuration](#Configuration)
-- [sender].fast_retrieval, see [Configuration](#Configuration)
-- [sender].max_price, see [Configuration](#Configuration)
-- [sender].start_epoch_hours, see [Configuration](#Configuration)
-- [sender].expire_days, see [Configuration](#Configuration)
-- [sender].generate_md5, when it is true and there is no md5 in car.json, then generate md5 for source files and car files, see [Configuration](#Configuration)
-- [sender].wallet, see [Configuration](#Configuration)
-- [sender].skip_confirmation, see [Configuration](#Configuration)
-- [sender].duration, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [main].storage_server_type, see [Configuration](#Configuration)
-- [main].api_url, see [Configuration](#Configuration)
-- [main].api_key, see [Configuration](#Configuration)
-- [main].access_token, see [Configuration](#Configuration)
-- [web_server].download_url_prefix, used only when `[main].storage_server_type="web server"`, see [Configuration](#Configuration)
-- [lotus].client_api_url, see [Configuration](#Configuration)
-- [lotus].client_access_token, see [Configuration](#Configuration)
+OPTIONS:
+   --name value                          task name
+   --input-dir value, -i value           absolute path where the json or csv format source files
+   --out-dir value, -o value             directory where target files will in (default: "/tmp/tasks")
+   --auto-bid                            send the auto-bid task (default: false)
+   --manual-bid                          send the manual-bid task (default: false)
+   --miners value                        minerID is required when send private task (pass comma separated array of minerIDs)
+   --dataset value                       curated dataset
+   --description value, -d value         task description
+   --max-copy-number value, --max value  max copy numbers when send auto-bid or manual-bid task (default: 1)
+
+```
 
 **Files generated after this step:**
-- [task-name]-metadata.json: Contains more content for creating proposal in the next step. Uuid will be updated based upon car.json generated in last step. See [Offline Deal](#Offline-Deal)
+- `[task-name]-metadata.json`: contains `Uuid` and `Deals` for storage providers to import deals.
 
-### Option:two: Manual-bid or Auto-Bid mode
-- **Conditions:** `[sender].public_deal=true` and `[sender].bid_mode=1`, see [Configuration](#Configuration)
+### Auto-bid Task
 ```shell
-./swan-client task -input-dir [car_files_dir] -out-dir [output_files_dir] -dataset [curated_dataset] -description [description]
-```
-**Command parameters used in this step:**
-- -input-dir(Required): Input directory where the generated car files and metadata files reside in.
-- -out-dir(optional): Metadata files and swan task file will be generated to this directory. When ommitted, use default `[send].output_dir`, see [Configuration](#Configuration)
-- -dataset(optional): The curated dataset from which the car files are generated
-- -description(optional): Details to better describe the data and confine the task or anything the storage provider needs to be informed.
+./swan-client task --input-dir [json_or_csv_absolute_path] --out-dir [output_files_dir] --auto-bid true --max-copy-number 5
 
-**Configurations used in this step:**
-- [sender].public_deal, see [Configuration](#Configuration)
-- [sender].bid_mode, see [Configuration](#Configuration)
-- [sender].verified_deal, see [Configuration](#Configuration)
-- [sender].offline_mode, see [Configuration](#Configuration)
-- [sender].fast_retrieval, see [Configuration](#Configuration)
-- [sender].max_price, see [Configuration](#Configuration)
-- [sender].start_epoch_hours, see [Configuration](#Configuration)
-- [sender].expire_days, see [Configuration](#Configuration)
-- [sender].generate_md5, when it is true and there is no md5 in car.json, then generate md5 for source files and car files, see [Configuration](#Configuration)
-- [sender].duration, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [main].storage_server_type, see [Configuration](#Configuration)
-- [main].api_url, see [Configuration](#Configuration)
-- [main].api_key, see [Configuration](#Configuration)
-- [main].access_token, see [Configuration](#Configuration)
-- [web_server].download_url_prefix, used only when `[main].storage_server_type="web server"`, see [Configuration](#Configuration)
+
+OPTIONS:
+   --name value                          task name
+   --input-dir value, -i value           absolute path where the json or csv format source files
+   --out-dir value, -o value             directory where target files will in (default: "/tmp/tasks")
+   --auto-bid                            send the auto-bid task (default: false)
+   --manual-bid                          send the manual-bid task (default: false)
+   --miners value                        minerID is required when send private task (pass comma separated array of minerIDs)
+   --dataset value                       curated dataset
+   --description value, -d value         task description
+   --max-copy-number value, --max value  max copy numbers when send auto-bid or manual-bid task (default: 1)
+
+```
+**Files generated after this step:**
+- `[task-name]-metadata.json`: contains `Uuid` and `Deals` for storage providers to import deals.
+
+### Manual-bid Task
+You can create manual-bid task on the swan platform. And each storage providers can apply this task from swan platform. After that, you can send deals to the storage providers.
+
+ **(1) Create manulal-bid task:**
+```shell
+./swan-client task --input-dir [json_or_csv_absolute_path] --out-dir [output_files_dir] --manual-bid true --max-copy-number 5
+
+
+OPTIONS:
+   --name value                          task name
+   --input-dir value, -i value           absolute path where the json or csv format source files
+   --out-dir value, -o value             directory where target files will in (default: "/tmp/tasks")
+   --auto-bid                            send the auto-bid task (default: false)
+   --manual-bid                          send the manual-bid task (default: false)
+   --miners value                        minerID is required when send private task (pass comma separated array of minerIDs)
+   --dataset value                       curated dataset
+   --description value, -d value         task description
+   --max-copy-number value, --max value  max copy numbers when send auto-bid or manual-bid task (default: 1)
+```
+**Files generated after this step:**
+- `[task-name]-metadata.json`: contains `Uuid` sourfile and CAR file infomation.
+
+
+**(2) Send deals to the storage providers:**
+```shell
+./swan-client deal --json [path]/[task-name]-metadata.json -out-dir [output_files_dir] -miners [storage_provider_id1,storage_provider_id2,... ]
+
+OPTIONS:
+   --csv value                the CSV file path of deal metadata
+   --json value               the JSON file path of deal metadata
+   --out-dir value, -o value  directory where target files will in (default: "/tmp/tasks")
+   --miners value             minerID is required when send manual-bid task (pass comma separated array of minerIDs)
+
+```
 
 **Files generated after this step:**
-- [task-name]-metadata.json: Contains more content for creating proposal in the next step. Uuid will be updated based upon car.json generated in last step. See [Offline Deal](#Offline-Deal)
+- `[task-name]-deals.json`: `Deals`infomation updated based on `[task-name]-metadata.json` generated on previous step
 
-## Send Deals
-:bell: The input dir and out dir should only be absolute one.
+---
+## 2. Blockchain RPC Service
+The second feature of swan-client is blockchain rpc service. It is supported by [POKT RPCList](https://rpclist.info). As the first version, swan-client provides users [deploy a RPC service](#21-Deploy-RPC-Service) and uses [RPC Command Service](#22-RPC-Command-Service). It is worth noting that the blockchain RPC services provided by swan-client are free at present. 
 
-:bell: This step is only necessary for Manual-bid or Auto-bid tasks, since for None-bid tasks, the step [Create A Task](#Create-A-Task) includes sending deals. You can choose one of the following 2 options according to your task bid_mode.
-### Option:one: Manual deal
-**Conditions:**
-- `task can be found by uuid in JSON file from swan platform`
-- `task.bid_mode=0`
+  * The following table shows the full list of supported chain until now.
 
-```shell
-./swan-client deal -json [path]/[task-name]-metadata.json -out-dir [output_files_dir] -miner [storage_provider_ids]
+	ChainID | ChainName
+	:-: | :-:
+	1| Ethereum Mainnet
+	2| Binance Smart Chain Mainnet
+	3 | Avalanche C-Chain
+	4 | Polygon Mainnet
+	5 | Fantom Opera
+	6 | Gnosis Chain (formerly xDai)
+	7 | IoTeX Network Mainnet
+	8 | Harmony Mainnet Shard 0
+	9 | Boba Network
+	10 | Fuse Mainnet
+	11 | DFK Chain
+	12 | Evmos
+	13 | Swimmer Network
+
+### 2.1 Deploy RPC Service
+
+You can deploy your RPC service by the following command. And the example give you a test case of your rpc service. More importantly, the RPC service provided by swan-client is compatible with thirteen public chain jsonrpc-api. The detail of public chain RPC-API documents and blockchain browsers can be found [here](document/rpc-cmd-example.md ':include') 
 ```
-**Command parameters used in this step:**
-- -json(Required): Full file path to the metadata JSON file, see [Offline Deal](#Offline-Deal)
-- -out-dir(optional): Swan deal final metadata files will be generated to the given directory. When ommitted, use default: `[sender].output_dir`. See [Configuration](#Configuration)
-- -miner(Required): Storage provider Ids you want to send car files to, miners separated by comma if there are more than one, e.g `f01276` or `t03354,f01276`
-
-**Configurations used in this step:**
-- [sender].wallet, see [Configuration](#Configuration)
-- [sender].verified_deal, see [Configuration](#Configuration)
-- [sender].fast_retrieval, see [Configuration](#Configuration)
-- [sender].start_epoch_hours, see [Configuration](#Configuration)
-- [sender].skip_confirmation, see [Configuration](#Configuration)
-- [sender].max_price, see [Configuration](#Configuration)
-- [sender].duration, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [main].api_url, see [Configuration](#Configuration)
-- [main].api_key, see [Configuration](#Configuration)
-- [main].access_token, see [Configuration](#Configuration)
-
-**Files generated after this step:**
-- [task-name]-deals.json: Deal CID updated based on [task-name]-metadata.json generated on previous step, see [Offline Deal](#Offline-Deal)
-
-### Option:two: Auto-bid deal
-- After a miner is allocated to a car file by Market Matcher, the client needs to send auto-bid deals using the information submitted to swan in step [Create A Task](#Create-A-Task).
-- This step is executed in infinite loop mode, it will send auto-bid deals contiuously when there are deals that can meet below conditions.
-
-**Conditions:**
-- `your tasks in swan`
-- `task.bid_mode=1`
-- `offline_deals.status=Assigned`
-
-```shell
-./swan-client auto -out-dir [output_files_dir]
+nohup swan-client daemon >> swan-client.log 2>&1 &
 ```
-**Command parameters used in this step:**
-- -out-dir(optional): Swan deal final metadata files will be generated to the given directory. When ommitted, use default: `[sender].output_dir`. See [Configuration](#Configuration)
-
-**Configurations used in this step:**
-- [sender].wallet, see [Configuration](#Configuration)
-- [sender].output_dir, only used when -out-dir is omitted in command, see [Configuration](#Configuration)
-- [main].api_url, see [Configuration](#Configuration)
-- [main].api_key, see [Configuration](#Configuration)
-- [main].access_token, see [Configuration](#Configuration)
-
-**Files generated for each task after this step:**
-- [task-name]-auto-deals.json: Deal CID updated based on [task-name]-metadata.json generated on next step. See [Offline Deal](#Offline-Deal)
-
-**Note:**
-- Logs are in directory ./logs
-- You can add `nohup` before `./swan-client` to ignore the HUP (hangup) signal and therefore avoid stop when you log out.
-- You can add `>> swan-client.log` in the command to let all the logs output to `swan-client.log`.
-- You can add `&` at the end of the command to let the program run in background.
-- Such as:
+ -  Example:
 ```shell
-nohup ./swan-client auto -out-dir [output_files_dir] >> swan-client.log &
+$ curl --location --request POST '127.0.0.1:8099/chain/rpc' \
+--header 'Content-Type: application/json' \
+--data-raw '{ \
+    "chain_id":"1", \
+    "params": "{\"jsonrpc\":\"2.0\",\"method\":\"eth_blockNumber\",\"id\":1}"}'
+
+output: 
+       {"id":1,"jsonrpc":"2.0","result":"0xf1c622"}
 ```
+### 2.2 RPC Command Service
+The RPC command can help you query the latest chain height and wallet balance, the cases of Ethereum and Binance Smart Chain are as follows:
+
+ -  (1) Ethereum Mainnet:
+```
+# query the current height
+$ swan-client rpc height --chain ETH
+
+output:
+        Chain: ETH
+        Height: 15844685
+
+# query the balance of the current height wallet
+$ swan-client rpc balance --chain ETH --address 0x29D5527CaA78f1946a409FA6aCaf14A0a4A0274b
+    
+output:
+        Chain: ETH
+        Height: 15844698
+        Address: 0x29D5527CaA78f1946a409FA6aCaf14A0a4A0274b
+        Balance: 749.53106079798394945
+```
+ - (2) Binance Smart Chain Mainnet:
+```
+# query the current height
+$ swan-client rpc height --chain BNB
+
+output:
+        Chain: BNB
+        Height: 22558967
+
+# query the balance of the current height wallet
+$ swan-client rpc balance --chain BNB --address 0x4430b3230294D12c6AB2aAC5C2cd68E80B16b581
+
+output:
+        Chain: BNB
+        Height: 22559008
+        Address: 0x4430b3230294D12c6AB2aAC5C2cd68E80B16b581
+        Balance: 0.027942338705784518
+```
+* More examples can be seen [here](document/rpc-cmd-example.md ':include')

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ client_access_token = ""                       # Access token of lotus client we
 
 [main]
 api_url = "https://go-swan-server.filswan.com" # Swan API address. For Swan production, it is `https://go-swan-server.filswan.com`. It can be ignored if `[sender].offline_swan=true`
-api_key = "" # Swan API key. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
-access_token = ""                              # Swan API access token. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
+api_key = "" # Swan API key. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_swan=true`.
+access_token = ""                              # Swan API access token. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_swan=true`.
 
 [ipfs_server]
 download_url_prefix = "http://[ip]:[port]"     # IPFS server url prefix. Store CAR files for downloading by storage provider. The downloading url will be `[download_url_prefix]/ipfs/[dataCID]`

--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ Swan-client is an important Web3 toolkit. It provides different tools to help us
 	- [2.1 Deploy RPC Service](#21-Deploy-RPC-Service)
 	- [2.2 RPC Command Service](#22-RPC-Command-Service)
 ## 1. Filecoin Deal Sender
-As a PiB level data onboarding tool for Filecoin Network, Swan-client can help users prepare data and send the data to storage providers in Filecoin network. The main features and steps are as follows:
- - Generate CAR files from your source files by [graphsplit](#Graphsplit), [lotus](#Lotus-API), [IPFS](#IPFS-API) or [ipfs-car](#ipfs-car).
- - Upload the CAR files to IPFS server and generate metadata file(JSON and CSV) for sending offline-deals. 
- - Propose offline-deals based on the metadata file.
+As a PiB-level data onboarding tool for Filecoin Network, Swan-client can help users prepare data and send the data to storage providers in the Filecoin network. The main features and steps are as follows:
+ - Generate CAR files from your source files by [graphsplit](#Graphsplit), [lotus](#Lotus-API), [IPFS](#IPFS-API), or [ipfs-car](#ipfs-car).
+ - Upload the CAR files to the IPFS server and generate metadata files (JSON and CSV) for sending offline deals. 
+ - Propose offline deals based on the metadata file.
  - Generate a final metadata file for storage providers to import deals.
- - Create tasks and offline-deals on [Swan Platform](https://console.filswan.com/#/dashboard).
+ - Create tasks and offline deals on [Swan Platform](https://console.filswan.com/#/dashboard).
 
  	**(Storage Providers can automatically import the deals by [Swan-Provider](https://github.com/filswan/go-swan-provider/tree/release-2.0.0))**
 
-swan-client can help users send their data to storage providers by creating three different kind of tasks. The complete process from the source file to the storage provider is as follows:
+swan-client can help users send their data to storage providers by creating three different kinds of tasks. The complete process from the source file to the storage provider is as follows:
  - **Private Task**
 <img src="http://yuml.me/diagram/plain/activity/(start)->(Generate CAR Files)->(Upload CAR Files to IPFS)->(Create Private Task)->(end)" >
  
@@ -87,7 +87,7 @@ api_key = "" # Swan API key. Acquire from [Swan Platform](https://console.filswa
 access_token = ""                              # Swan API access token. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_swan=true`.
 
 [ipfs_server]
-download_url_prefix = "http://[ip]:[port]"     # IPFS server url prefix. Store CAR files for downloading by storage provider. The downloading url will be `[download_url_prefix]/ipfs/[dataCID]`
+download_url_prefix = "http://[ip]:[port]"     # IPFS server url prefix. Store CAR files for downloading by the storage provider. The downloading url will be `[download_url_prefix]/ipfs/[dataCID]`
 upload_url_prefix = "http://[ip]:[port]"       # IPFS server url for uploading files
 
 [sender]
@@ -98,17 +98,17 @@ skip_confirmation = false                      # Whether to skip manual confirma
 generate_md5 = false                           # Whether to generate md5 for each car file and source file(resource consuming)
 wallet = ""                                    # Wallet used for sending offline deals
 max_price = "0"                                # Max price willing to pay per GiB/epoch for offline deals
-start_epoch_hours = 96                         # Specify hours that the deal should after at (default 96 hours)
+start_epoch_hours = 96                         # Specify hours that the deal should be after at (default 96 hours)
 expire_days = 4                                # Specify days that the deal will expire after (default 4 days) 
-duration = 1512000                             # How long the Storage Providers should store the data for, in blocks(30s/block), default 1512000.
+duration = 1512000                             # How long the Storage Providers should store the data for, in blocks(the 30s/block), default 1512000.
 start_deal_time_interval = 500                 # The interval between two deals sent, default: 500ms
 ```
 
 ### 1.3 Generate CAR Files
-A CAR file is an independent unit to be sent to storage providers, swan-client provides four different ways to generate CAR files, and the CAR file will be imported to lotus.
+A CAR file is an independent unit to be sent to storage providers, swan-client provides four different ways to generate CAR files, and the CAR file will be imported to the lotus.
 
 #### Graphsplit
-:bell: This option can split a file under source directory or the files in a whole directory to one or more car file(s) in output directory.
+:bell: This option can split a file under the source directory or the files in a whole directory to one or more car file(s) in output directory.
 ```shell
 ./swan-client generate-car graphsplit car --input-dir [input_files_dir] --out-dir [car_files_output_dir]
 
@@ -118,14 +118,14 @@ OPTIONS:
    --import                          whether to import CAR file to lotus (default: true)
    --parallel value                  number goroutines run when building ipld nodes (default: 5)
    --slice-size value, --size value  bytes of each piece (default: 17179869184)
-   --parent-path                     generate CAR file based on whole folder (default: true)
+   --parent-path                     generate CAR file based on the whole folder (default: true)
 ```
 
 **Files generated after this step:**
 - `manifest.csv`: A metadata file generated by `graphsplit API`
 - `car.json`: contains information for both source files and CAR files
 - `car.csv`: contains information for both source files and CAR files
-- `[dataCID].car`: if `--parent-path=true` is set, the CAR files generated based on the whole directory, otherwize based on each file according to file size and `--slice-size`
+- `[dataCID].car`: if `--parent-path=true` is set, the CAR files are generated based on the whole directory, otherwise based on each file according to the file size and `--slice-size`
 
 Credits should be given to filedrive-team. More information can be found [here](https://github.com/filedrive-team/go-graphsplit)
 
@@ -148,7 +148,7 @@ OPTIONS:
 - `[source-file-name].car`: each source file has a related CAR file
 
 #### IPFS API
-:bell: This option will merge files under source directory to one car file in output directory using IPFS API.
+:bell: This option will merge files under the source directory to one car file in the output directory using IPFS API.
 
 :bell: A running **IPFS** node is required.
 
@@ -161,14 +161,14 @@ OPTIONS:
    --import                     whether to import CAR file to lotus (default: true)
 ```
 **Files generated after this step:**
-- `car.json`: contains information for CAR file
-- `car.csv`: contains information for CAR file
+- `car.json`: contains information for the CAR file
+- `car.csv`: contains information for the CAR file
 - `[dataCID].car`: the source file(s) will be merged into this car file
 
 #### ipfs-car 
-:bell: `ipfs-car` pacakage is **required**: `sudo npm install -g ipfs-car`
+:bell: `ipfs-car` package is **required**: `sudo npm install -g ipfs-car`
 
-:bell: This option will merge files under source directory to one car file in output directory using `ipfs-car` command.
+:bell: This option will merge files under source directory to one car file in the output directory using `ipfs-car` command.
 ```shell
 ./swan-client generate-car ipfs-car --input-dir [input_files_dir] --out-dir [car_file_output_dir]
 
@@ -179,8 +179,8 @@ OPTIONS:
 ```
 
 **Files generated after this step:**
-- `car.json`: contains information for CAR file
-- `car.csv`: contains information for CAR file
+- `car.json`: contains information for the CAR file
+- `car.csv`: contains information for the CAR file
 - `[source-files-dir-name].car`: the source file(s) will be merged into this CAR file
 
 ### 1.4 Upload CAR Files to IPFS
@@ -198,7 +198,7 @@ OPTIONS:
 - `car.csv`: the `CarFileUrl` of CAR files will be updated
 
 ### 1.5 Create A Task
-You can create three different kind of task using the `car.json` or `car.csv` 
+You can create three different kinds of tasks using the `car.json` or `car.csv` 
 #### Private Task
 You can directly send deals to miners by creating a  private task
 
@@ -208,13 +208,13 @@ You can directly send deals to miners by creating a  private task
 OPTIONS:
    --name value                          task name
    --input-dir value, -i value           absolute path where the json or csv format source files
-   --out-dir value, -o value             directory where target files will in (default: "/tmp/tasks")
+   --out-dir value, -o value             directory where target files will be in (default: "/tmp/tasks")
    --auto-bid                            send the auto-bid task (default: false)
    --manual-bid                          send the manual-bid task (default: false)
-   --miners value                        minerID is required when send private task (pass comma separated array of minerIDs)
+   --miners value                        miners is required when sending private task (pass comma separated array of minerIDs)
    --dataset value                       curated dataset
    --description value, -d value         task description
-   --max-copy-number value, --max value  max copy numbers when send auto-bid or manual-bid task (default: 1)
+   --max-copy-number value, --max value  max copy numbers when sending auto-bid or manual-bid task (default: 1)
 
 ```
 
@@ -232,17 +232,17 @@ OPTIONS:
    --out-dir value, -o value             directory where target files will in (default: "/tmp/tasks")
    --auto-bid                            send the auto-bid task (default: false)
    --manual-bid                          send the manual-bid task (default: false)
-   --miners value                        minerID is required when send private task (pass comma separated array of minerIDs)
+   --miners value                        miners is required when sending private task (pass comma separated array of minerIDs)
    --dataset value                       curated dataset
    --description value, -d value         task description
-   --max-copy-number value, --max value  max copy numbers when send auto-bid or manual-bid task (default: 1)
+   --max-copy-number value, --max value  max copy numbers when sending auto-bid or manual-bid task (default: 1)
 
 ```
 **Files generated after this step:**
 - `[task-name]-metadata.json`: contains `Uuid` and `Deals` for storage providers to import deals.
 
 ### Manual-bid Task
-You can create manual-bid task on the swan platform. And each storage providers can apply this task from swan platform. After that, you can send deals to the storage providers.
+You can create manual-bid tasks on the swan platform. And each storage provider can apply this task from swan platform. After that, you can send deals to the storage providers.
 
  **(1) Create manulal-bid task:**
 ```shell
@@ -255,13 +255,13 @@ OPTIONS:
    --out-dir value, -o value             directory where target files will in (default: "/tmp/tasks")
    --auto-bid                            send the auto-bid task (default: false)
    --manual-bid                          send the manual-bid task (default: false)
-   --miners value                        minerID is required when send private task (pass comma separated array of minerIDs)
+   --miners value                        miners is required when sending private task (pass comma separated array of minerIDs)
    --dataset value                       curated dataset
    --description value, -d value         task description
-   --max-copy-number value, --max value  max copy numbers when send auto-bid or manual-bid task (default: 1)
+   --max-copy-number value, --max value  max copy numbers when sending auto-bid or manual-bid task (default: 1)
 ```
 **Files generated after this step:**
-- `[task-name]-metadata.json`: contains `Uuid` sourfile and CAR file infomation.
+- `[task-name]-metadata.json`: contains the `Uuid`, source file information, and CAR file information.
 
 
 **(2) Send deals to the storage providers:**
@@ -272,18 +272,18 @@ OPTIONS:
    --csv value                the CSV file path of deal metadata
    --json value               the JSON file path of deal metadata
    --out-dir value, -o value  directory where target files will in (default: "/tmp/tasks")
-   --miners value             minerID is required when send manual-bid task (pass comma separated array of minerIDs)
+   --miners value             miners is required when sending manual-bid task (pass comma separated array of minerIDs)
 
 ```
 
 **Files generated after this step:**
-- `[task-name]-deals.json`: `Deals`infomation updated based on `[task-name]-metadata.json` generated on previous step
+- `[task-name]-deals.json`: `Deals`infomation updated based on `[task-name]-metadata.json` generated on the previous step
 
 ---
 ## 2. Blockchain RPC Service
-The second feature of swan-client is blockchain rpc service. It is supported by [POKT RPCList](https://rpclist.info). As the first version, swan-client provides users [deploy a RPC service](#21-Deploy-RPC-Service) and uses [RPC Command Service](#22-RPC-Command-Service). It is worth noting that the blockchain RPC services provided by swan-client are free at present. 
+The second feature of swan-client is the blockchain RPC service. It is supported by [POKT RPCList](https://rpclist.info). As the first version, swan-client provides users [deploy a RPC service](#21-Deploy-RPC-Service) and uses [RPC Command Service](#22-RPC-Command-Service). It is worth noting that the blockchain RPC services provided by swan-client are free at present. 
 
-  * The following table shows the full list of supported chain until now.
+  * The following table shows the full list of the supported chain until now.
 
 	ChainID | ChainName
 	:-: | :-:

--- a/command/auto.go
+++ b/command/auto.go
@@ -627,27 +627,18 @@ func QueryBalance(chain string, height int64, address string) (info ChainInfo, e
 		errCode := int(errorInfo["code"].(float64))
 		errMsg := errorInfo["message"].(string)
 		logs.GetLogger().Errorf("get %s balance failed, code: %d error: %s", chain, errCode, errMsg)
+		err = errors.New(errMsg)
 		return
 	}
 
+	fbalance := new(big.Float)
 	switch balance.(type) {
 	case float64:
-		fbalance := new(big.Float)
 		fbalance.SetFloat64(balance.(float64))
-		info.Balance = new(big.Float).Quo(fbalance, big.NewFloat(math.Pow10(18)))
 	case string:
-		hex := balance.(string)
-		val := hex[2:]
-		var data uint64
-		data, err = strconv.ParseUint(val, 16, 64)
-		if err != nil {
-			logs.GetLogger().Errorf("convert balance value failed, error: %v", err)
-			return
-		}
-		fbalance := new(big.Float)
-		fbalance.SetUint64(data)
-		info.Balance = new(big.Float).Quo(fbalance, big.NewFloat(math.Pow10(18)))
+		fbalance.SetString(balance.(string))
 	}
+	info.Balance = new(big.Float).Quo(fbalance, big.NewFloat(math.Pow10(18)))
 	return
 }
 

--- a/command/auto.go
+++ b/command/auto.go
@@ -1,8 +1,15 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"math"
+	"math/big"
+	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -441,4 +448,242 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) SendAutoBidDealsBySwanClientSourceId(input
 	}
 END:
 	logs.GetLogger().Infof("auto send deal end,dealTotalCount: %d,successed: %d,failed: %d", total, successCount, total-successCount)
+}
+
+func SendRpcReqAndResp(chainId, params string) (result []byte, err error) {
+	urls, ok := publicChain[chainId]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("not support chainId: %s", chainId))
+	}
+
+	for _, u := range urls {
+		copyUrl := u
+		result, err = doReq(copyUrl, params)
+		if err != nil {
+			if len(urls) > 0 {
+				fmt.Printf("occur error, msg: %v, retry it ...", err)
+				continue
+			}
+			fmt.Printf("occur error, msg: %v", err)
+		}
+		break
+	}
+	return
+}
+
+func doReq(reqUrl, params string) ([]byte, error) {
+	client := http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Post(reqUrl, "application/json", strings.NewReader(params))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}
+
+func QueryChainInfo(chain string, height int64, address string) (ChainInfo, error) {
+	if utils.IsStrEmpty(&address) {
+		return QueryHeight(chain)
+	} else {
+		return QueryBalance(chain, height, address)
+	}
+}
+
+func QueryHeight(chain string) (info ChainInfo, err error) {
+	urls, ok := chainUrlMap[chain]
+	if !ok {
+		return info, errors.New(fmt.Sprintf("not support chainId: %s", chain))
+	}
+	var rpcParam rpcReq
+	switch chain {
+	case "ETH", "BNB", "MATIC", "FTM", "xDAI", "IOTX", "BOBA", "EVMOS", "AVAX", "FUSE", "JEWEL", "TUS":
+		rpcParam.Jsonrpc = "2.0"
+		rpcParam.Method = "eth_blockNumber"
+		rpcParam.Params = []interface{}{}
+		rpcParam.Id = 83
+	case "ONE":
+		rpcParam.Jsonrpc = "2.0"
+		rpcParam.Method = "hmyv2_blockNumber"
+		rpcParam.Id = 1
+		rpcParam.Params = []interface{}{}
+	}
+
+	var data []byte
+	for _, u := range urls {
+		copyUrl := u
+		rpcParamBytes, err := json.Marshal(rpcParam)
+		if err != nil {
+			logs.GetLogger().Errorf("generate req params bytes failed,error: %v", err)
+			continue
+		}
+		data, err = doReq(copyUrl, string(rpcParamBytes))
+		if err != nil {
+			logs.GetLogger().Errorf("request url: %s failed, error: %v", copyUrl, err)
+			if len(urls) > 0 {
+				logs.GetLogger().Warnf("retry it by other request")
+				continue
+			}
+			break
+		}
+		break
+	}
+
+	height := utils.GetFieldFromJson(data, "result")
+	errorInfo := GetFieldMapFromJsonByError(data)
+
+	if errorInfo != nil {
+		errCode := int(errorInfo["code"].(float64))
+		errMsg := errorInfo["message"].(string)
+		logs.GetLogger().Errorf("get %s height failed, code: %d error: %s", chain, errCode, errMsg)
+		return
+	}
+
+	switch height.(type) {
+	case float64:
+		info.Height = uint64(height.(float64))
+	case string:
+		hex := height.(string)
+		val := hex[2:]
+		var data uint64
+		data, err = strconv.ParseUint(val, 16, 64)
+		if err != nil {
+			logs.GetLogger().Errorf("convert height value failed, error: %v", err)
+			return
+		}
+		info.Height = data
+	}
+
+	return
+}
+
+func QueryBalance(chain string, height int64, address string) (info ChainInfo, err error) {
+	urls, ok := chainUrlMap[chain]
+	if !ok {
+		return info, errors.New(fmt.Sprintf("not support chainId: %s", chain))
+	}
+
+	// IOTX need change wallet to eth wallet
+	var rpcParam rpcReq
+	switch chain {
+	case "ETH", "BNB", "MATIC", "FTM", "xDAI", "IOTX", "BOBA", "EVMOS", "AVAX", "FUSE", "JEWEL", "TUS":
+		rpcParam.Jsonrpc = "2.0"
+		rpcParam.Method = "eth_getBalance"
+		chainHeight := "latest"
+		rpcParam.Id = 1
+		if height != 0 {
+			chainHeight = strconv.Itoa(int(height))
+			info.Height = uint64(height)
+		} else {
+			queryHeight, err := QueryHeight(chain)
+			if err != nil {
+				return queryHeight, err
+			}
+			info.Height = queryHeight.Height
+		}
+		rpcParam.Params = []interface{}{address, chainHeight}
+
+	case "ONE":
+		rpcParam.Jsonrpc = "2.0"
+		rpcParam.Method = "hmyv2_getBalanceByBlockNumber"
+		rpcParam.Id = 1
+		if height != 0 {
+			info.Height = uint64(height)
+		} else {
+			queryHeight, err := QueryHeight(chain)
+			if err != nil {
+				return queryHeight, err
+			}
+			info.Height = queryHeight.Height
+		}
+		rpcParam.Params = []interface{}{address, info.Height}
+	}
+
+	info.Address = address
+	var data []byte
+	for _, u := range urls {
+		copyUrl := u
+		rpcParamBytes, err := json.Marshal(rpcParam)
+		if err != nil {
+			logs.GetLogger().Errorf("generate req params bytes failed,error: %v", err)
+			continue
+		}
+		data, err = doReq(copyUrl, string(rpcParamBytes))
+		if err != nil {
+			logs.GetLogger().Errorf("request url: %s failed, error: %v", copyUrl, err)
+			if len(urls) > 0 {
+				logs.GetLogger().Warnf("retry it by other request")
+				continue
+			}
+			break
+		}
+	}
+
+	balance := utils.GetFieldFromJson(data, "result")
+	errorInfo := GetFieldMapFromJsonByError(data)
+
+	if errorInfo != nil {
+		errCode := int(errorInfo["code"].(float64))
+		errMsg := errorInfo["message"].(string)
+		logs.GetLogger().Errorf("get %s balance failed, code: %d error: %s", chain, errCode, errMsg)
+		return
+	}
+
+	switch balance.(type) {
+	case float64:
+		fbalance := new(big.Float)
+		fbalance.SetFloat64(balance.(float64))
+		info.Balance = new(big.Float).Quo(fbalance, big.NewFloat(math.Pow10(18)))
+	case string:
+		hex := balance.(string)
+		val := hex[2:]
+		var data uint64
+		data, err = strconv.ParseUint(val, 16, 64)
+		if err != nil {
+			logs.GetLogger().Errorf("convert balance value failed, error: %v", err)
+			return
+		}
+		fbalance := new(big.Float)
+		fbalance.SetUint64(data)
+		info.Balance = new(big.Float).Quo(fbalance, big.NewFloat(math.Pow10(18)))
+	}
+	return
+}
+
+type ChainInfo struct {
+	Height  uint64
+	Balance *big.Float
+	Address string
+}
+
+// {"jsonrpc":"2.0","method":"eth_getBalance","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"],"id":1}
+type rpcReq struct {
+	Jsonrpc string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+	Id      int           `json:"id"`
+}
+
+type rpcResp struct {
+	Id      int    `json:"id"`
+	Jsonrpc string `json:"jsonrpc"`
+	Result  string `json:"result"`
+	Error   struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func GetFieldMapFromJsonByError(jsonBytes []byte) map[string]interface{} {
+	fieldVal := utils.GetFieldFromJson(jsonBytes, "error")
+	if fieldVal == nil {
+		return nil
+	}
+	switch fieldValType := fieldVal.(type) {
+	case map[string]interface{}:
+		return fieldValType
+	default:
+		return nil
+	}
 }

--- a/command/auto.go
+++ b/command/auto.go
@@ -46,7 +46,7 @@ func GetCmdAutoDeal(outputDir *string) *CmdAutoBidDeal {
 	if !utils.IsStrEmpty(outputDir) {
 		cmdAutoBidDeal.OutputDir = *outputDir
 	} else {
-		cmdAutoBidDeal.OutputDir = filepath.Join(config.GetConfig().Sender.OutputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
+		cmdAutoBidDeal.OutputDir = filepath.Join(*outputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
 	}
 
 	return cmdAutoBidDeal
@@ -138,7 +138,7 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) sendAutoBidDealsBySourceId(sourceId int) (
 			}
 		}
 
-		jsonFilepath, fileDescs, err := cmdAutoBidDeal.sendAutoBidDeals4Task(offlineDeals)
+		_, jsonFilepath, fileDescs, err := cmdAutoBidDeal.sendAutoBidDeals4Task(offlineDeals, nil)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			return nil, nil, err
@@ -169,7 +169,7 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) SendAutoBidDealsByTaskUuid(taskUuid string
 		return nil, nil, err
 	}
 
-	jsonFilepath, fileDescs, err := cmdAutoBidDeal.sendAutoBidDeals4Task(assignedOfflineDeals)
+	_, jsonFilepath, fileDescs, err := cmdAutoBidDeal.sendAutoBidDeals4Task(assignedOfflineDeals, nil)
 	if err != nil {
 		logs.GetLogger().Error(err)
 		return nil, nil, err
@@ -178,20 +178,20 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) SendAutoBidDealsByTaskUuid(taskUuid string
 	return jsonFilepath, fileDescs, nil
 }
 
-func (cmdAutoBidDeal *CmdAutoBidDeal) sendAutoBidDeals4Task(assignedOfflineDeals []*libmodel.OfflineDeal) (*string, []*libmodel.FileDesc, error) {
+func (cmdAutoBidDeal *CmdAutoBidDeal) sendAutoBidDeals4Task(assignedOfflineDeals []*libmodel.OfflineDeal, carSourceInfoMap map[string]*libmodel.FileDesc) (int, *string, []*libmodel.FileDesc, error) {
 	if len(assignedOfflineDeals) == 0 {
 		logs.GetLogger().Info("no offline deals to be sent")
-		return nil, nil, nil
+		return 0, nil, nil, nil
 	}
 
 	swanClient, err := swan.GetClient(cmdAutoBidDeal.SwanApiUrl, cmdAutoBidDeal.SwanApiKey, cmdAutoBidDeal.SwanAccessToken, cmdAutoBidDeal.SwanToken)
 	if err != nil {
 		logs.GetLogger().Error(err)
-		return nil, nil, err
+		return 0, nil, nil, err
 	}
 
+	var successCount int
 	fileDescs := []*libmodel.FileDesc{}
-
 	for _, assignedOfflineDeal := range assignedOfflineDeals {
 		fileDesc, err := cmdAutoBidDeal.sendAutobidDeal(assignedOfflineDeal)
 		if err != nil {
@@ -201,6 +201,18 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) sendAutoBidDeals4Task(assignedOfflineDeals
 
 		if fileDesc == nil {
 			continue
+		}
+
+		if carSourceInfoMap != nil {
+			if carSourceInfo, ok := carSourceInfoMap[fileDesc.PayloadCid]; ok {
+				fileDesc.SourceFileName = carSourceInfo.SourceFileName
+				fileDesc.SourceFilePath = carSourceInfo.SourceFilePath
+				fileDesc.SourceFileMd5 = carSourceInfo.SourceFileMd5
+				fileDesc.SourceFileSize = carSourceInfo.SourceFileSize
+				fileDesc.CarFileName = carSourceInfo.CarFileName
+				fileDesc.CarFilePath = carSourceInfo.CarFilePath
+				fileDesc.CarFileMd5 = carSourceInfo.CarFileMd5
+			}
 		}
 
 		fileDescs = append(fileDescs, fileDesc)
@@ -227,6 +239,7 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) sendAutoBidDeals4Task(assignedOfflineDeals
 			logs.GetLogger().Error(err)
 			continue
 		}
+		successCount += 1
 	}
 
 	jsonFileName := *assignedOfflineDeals[0].TaskName + JSON_FILE_NAME_DEAL_AUTO
@@ -234,10 +247,10 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) sendAutoBidDeals4Task(assignedOfflineDeals
 	filepath, err := WriteCarFilesToFiles(fileDescs, cmdAutoBidDeal.OutputDir, jsonFileName, csvFileName)
 	if err != nil {
 		logs.GetLogger().Error(err)
-		return nil, nil, err
+		return successCount, nil, nil, err
 	}
 
-	return filepath, fileDescs, nil
+	return successCount, filepath, fileDescs, nil
 }
 
 func (cmdAutoBidDeal *CmdAutoBidDeal) sendAutobidDeal(offlineDeal *libmodel.OfflineDeal) (*libmodel.FileDesc, error) {
@@ -359,4 +372,73 @@ func (cmdAutoBidDeal *CmdAutoBidDeal) CheckDealStatus(dealCid string) (*lotus.Cl
 		return nil, err
 	}
 	return dealCostInfo, err
+}
+
+func (cmdAutoBidDeal *CmdAutoBidDeal) SendAutoBidDealsBySwanClientSourceId(inputDir string, taskUuid string, total int) {
+	swanClient, err := swan.GetClient(cmdAutoBidDeal.SwanApiUrl, cmdAutoBidDeal.SwanApiKey, cmdAutoBidDeal.SwanAccessToken, cmdAutoBidDeal.SwanToken)
+	if err != nil {
+		logs.GetLogger().Error(err)
+		return
+	}
+
+	var fileDescs []*libmodel.FileDesc
+	if strings.HasSuffix(inputDir, "json") {
+		fileDescs, err = ReadFileDescsFromJsonFile(inputDir, "")
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return
+		}
+	}
+	if strings.HasSuffix(inputDir, "csv") {
+		fileDescs, err = ReadFileFromCsvFile(inputDir, "")
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return
+		}
+	}
+
+	var carSourceInfoMap = make(map[string]*libmodel.FileDesc)
+	for _, desc := range fileDescs {
+		carSourceInfoMap[desc.PayloadCid] = desc
+	}
+
+	sourceId := libconstants.TASK_SOURCE_ID_SWAN_CLIENT
+	params := swan.GetOfflineDealsByStatusParams{
+		DealStatus: libconstants.OFFLINE_DEAL_STATUS_ASSIGNED,
+		ForMiner:   false,
+		SourceId:   &sourceId,
+	}
+
+	var totalCount, successCount int
+	tick := time.Tick(10 * time.Second)
+	for {
+		select {
+		case <-tick:
+			assignedOfflineDeals, err := swanClient.GetOfflineDealsByStatus(params)
+			if err != nil {
+				logs.GetLogger().Error(err)
+				continue
+			}
+			var offlineDeals []*libmodel.OfflineDeal
+			for _, offlineDeal := range assignedOfflineDeals {
+				if *offlineDeal.TaskUuid == taskUuid {
+					offlineDeals = append(offlineDeals, offlineDeal)
+				}
+			}
+			totalCount += len(offlineDeals)
+			success, _, _, err := cmdAutoBidDeal.sendAutoBidDeals4Task(offlineDeals, carSourceInfoMap)
+			if err != nil {
+				logs.GetLogger().Error(err)
+				continue
+			}
+			successCount += success
+			if totalCount == total {
+				goto END
+			}
+		case <-time.After(30 * time.Minute):
+			goto END
+		}
+	}
+END:
+	logs.GetLogger().Infof("auto send deal end,dealTotalCount: %d,successed: %d,failed: %d", total, successCount, total-successCount)
 }

--- a/command/auto.go
+++ b/command/auto.go
@@ -648,22 +648,11 @@ type ChainInfo struct {
 	Address string
 }
 
-// {"jsonrpc":"2.0","method":"eth_getBalance","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"],"id":1}
 type rpcReq struct {
 	Jsonrpc string        `json:"jsonrpc"`
 	Method  string        `json:"method"`
 	Params  []interface{} `json:"params"`
 	Id      int           `json:"id"`
-}
-
-type rpcResp struct {
-	Id      int    `json:"id"`
-	Jsonrpc string `json:"jsonrpc"`
-	Result  string `json:"result"`
-	Error   struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	} `json:"error"`
 }
 
 func GetFieldMapFromJsonByError(jsonBytes []byte) map[string]interface{} {

--- a/command/car.go
+++ b/command/car.go
@@ -88,6 +88,7 @@ func (cmdCar *CmdCar) CreateCarFiles() ([]*libmodel.FileDesc, error) {
 		fileDesc.SourceFilePath = filepath.Join(cmdCar.InputDir, fileDesc.SourceFileName)
 		fileDesc.SourceFileSize = srcFile.Size()
 		fileDesc.CarFileName = fileDesc.SourceFileName + ".car"
+		fileDesc.CarFileUrl = fileDesc.CarFileName
 		fileDesc.CarFilePath = filepath.Join(cmdCar.OutputDir, fileDesc.CarFileName)
 		logs.GetLogger().Info("Creating car file ", fileDesc.CarFilePath, " for ", fileDesc.SourceFilePath)
 

--- a/command/car.go
+++ b/command/car.go
@@ -23,27 +23,29 @@ type CmdCar struct {
 	OutputDir              string //required
 	InputDir               string //required
 	GenerateMd5            bool   //required
+	ImportFlag             bool
 }
 
-func GetCmdCar(inputDir string, outputDir *string) *CmdCar {
+func GetCmdCar(inputDir string, outputDir *string, importFlag bool) *CmdCar {
 	cmdCar := &CmdCar{
 		LotusClientApiUrl:      config.GetConfig().Lotus.ClientApiUrl,
 		LotusClientAccessToken: config.GetConfig().Lotus.ClientAccessToken,
 		InputDir:               inputDir,
 		GenerateMd5:            config.GetConfig().Sender.GenerateMd5,
+		ImportFlag:             importFlag,
 	}
 
 	if !utils.IsStrEmpty(outputDir) {
 		cmdCar.OutputDir = *outputDir
 	} else {
-		cmdCar.OutputDir = filepath.Join(config.GetConfig().Sender.OutputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
+		cmdCar.OutputDir = filepath.Join(*outputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
 	}
 
 	return cmdCar
 }
 
-func CreateCarFilesByConfig(inputDir string, outputDir *string) ([]*libmodel.FileDesc, error) {
-	cmdCar := GetCmdCar(inputDir, outputDir)
+func CreateCarFilesByConfig(inputDir string, outputDir *string, importFlag bool) ([]*libmodel.FileDesc, error) {
+	cmdCar := GetCmdCar(inputDir, outputDir, importFlag)
 	fileDescs, err := cmdCar.CreateCarFiles()
 	if err != nil {
 		logs.GetLogger().Error(err)
@@ -103,20 +105,30 @@ func (cmdCar *CmdCar) CreateCarFiles() ([]*libmodel.FileDesc, error) {
 
 		fileDesc.PieceCid = *pieceCid
 
-		dataCid, err := lotusClient.LotusClientImport(fileDesc.CarFilePath, true)
-		if err != nil {
-			err := fmt.Errorf("failed to import car file")
-			logs.GetLogger().Error(err)
-			return nil, err
-		}
+		if cmdCar.ImportFlag {
+			dataCid, err := lotusClient.LotusClientImport(fileDesc.CarFilePath, true)
+			if err != nil {
+				err := fmt.Errorf("failed to import car file")
+				logs.GetLogger().Error(err)
+				return nil, err
+			}
 
-		if dataCid == nil {
-			err := fmt.Errorf("failed to generate data cid for: %s", fileDesc.CarFilePath)
-			logs.GetLogger().Error(err)
-			return nil, err
-		}
+			if dataCid == nil {
+				err := fmt.Errorf("failed to generate data cid for: %s", fileDesc.CarFilePath)
+				logs.GetLogger().Error(err)
+				return nil, err
+			}
 
-		fileDesc.PayloadCid = *dataCid
+			fileDesc.PayloadCid = *dataCid
+		} else {
+			dataCid, _, _, err := CalculateValueByCarFile(fileDesc.CarFilePath, true, false)
+			if err != nil {
+				err := fmt.Errorf("failed to generate data cid for: %s", fileDesc.CarFilePath)
+				logs.GetLogger().Error(err)
+				return nil, err
+			}
+			fileDesc.PayloadCid = dataCid
+		}
 
 		fileDesc.CarFileSize = utils.GetFileSize(fileDesc.CarFilePath)
 

--- a/command/common.go
+++ b/command/common.go
@@ -48,6 +48,38 @@ const (
 	VERSION      = "2.0.0"
 )
 
+var publicChain = map[string][]string{
+	"1":  {"https://eth-mainnet.gateway.pokt.network/v1/5f3453978e354ab992c4da79", "https://eth-rpc.gateway.pokt.network"},                      // 1     Ethereum Mainnet
+	"2":  {"https://bsc-mainnet.gateway.pokt.network/v1/lb/6136201a7bad1500343e248d"},                                                           // 56    Binance Smart Chain Mainnet
+	"3":  {"https://api.avax.network/ext/bc/C/rpc", "https://avax-mainnet.gateway.pokt.network/v1/lb/605238bf6b986eea7cf36d5e/ext/bc/C/rpc"},    // 43114 Avalanche C-Chain
+	"4":  {"https://poly-rpc.gateway.pokt.network"},                                                                                             // 137   Polygon Mainnet
+	"5":  {"https://fantom-mainnet.gateway.pokt.network/v1/lb/6261a8a154c745003bcdb0f8"},                                                        // 250   Fantom Opera
+	"6":  {"https://xdai-rpc.gateway.pokt.network"},                                                                                             // 100   Gnosis Chain (formerly xDai)
+	"7":  {"https://pokt-api.iotex.io", "https://iotex-mainnet.gateway.pokt.network/v1/lb/6176f902e19001003499f492"},                            // 4689  IoTeX Network Mainnet
+	"8":  {"https://harmony-0-rpc.gateway.pokt.network"},                                                                                        // 1666600000 Harmony Mainnet Shard 0
+	"9":  {"https://boba-mainnet.gateway.pokt.network/v1/lb/623ad21b20354900396fed7f"},                                                          // 288   Boba Network
+	"10": {"https://fuse-rpc.gateway.pokt.network"},                                                                                             // 122   Fuse Mainnet
+	"11": {"https://avax-dfk.gateway.pokt.network/v1/lb/6244818c00b9f0003ad1b619/ext/bc/q2aTwKuyzgs8pynF7UXBZCU7DejbZbZ6EUyHr3JQzYgwNPUPi/rpc"}, // 53935  DFK Chain
+	"12": {"https://evmos-mainnet.gateway.pokt.network/v1/lb/627586ddea1b320039c95205"},                                                         // 9001   Evmos
+	"13": {"https://avax-cra-rpc.gateway.pokt.network"},                                                                                         // 73772  Swimmer Network
+}
+
+var chainUrlMap = map[string][]string{
+	"ETH":   {"https://eth-mainnet.gateway.pokt.network/v1/5f3453978e354ab992c4da79", "https://eth-rpc.gateway.pokt.network"},                      // 1     Ethereum Mainnet
+	"BNB":   {"https://bsc-mainnet.gateway.pokt.network/v1/lb/6136201a7bad1500343e248d"},                                                           // 56    Binance Smart Chain Mainnet
+	"AVAX":  {"https://api.avax.network/ext/bc/C/rpc", "https://avax-mainnet.gateway.pokt.network/v1/lb/605238bf6b986eea7cf36d5e/ext/bc/C/rpc"},    // 43114 Avalanche C-Chain
+	"MATIC": {"https://poly-rpc.gateway.pokt.network"},                                                                                             // 137   Polygon Mainnet
+	"FTM":   {"https://fantom-mainnet.gateway.pokt.network/v1/lb/6261a8a154c745003bcdb0f8"},                                                        // 250   Fantom Opera
+	"xDAI":  {"https://xdai-rpc.gateway.pokt.network"},                                                                                             // 100   Gnosis Chain (formerly xDai)
+	"IOTX":  {"https://pokt-api.iotex.io", "https://iotex-mainnet.gateway.pokt.network/v1/lb/6176f902e19001003499f492"},                            // 4689  IoTeX Network Mainnet
+	"ONE":   {"https://harmony-0-rpc.gateway.pokt.network"},                                                                                        // 1666600000 Harmony Mainnet Shard 0
+	"BOBA":  {"https://boba-mainnet.gateway.pokt.network/v1/lb/623ad21b20354900396fed7f"},                                                          // 288   Boba Network
+	"FUSE":  {"https://fuse-rpc.gateway.pokt.network"},                                                                                             // 122   Fuse Mainnet
+	"JEWEL": {"https://avax-dfk.gateway.pokt.network/v1/lb/6244818c00b9f0003ad1b619/ext/bc/q2aTwKuyzgs8pynF7UXBZCU7DejbZbZ6EUyHr3JQzYgwNPUPi/rpc"}, // 53935  DFK Chain
+	"EVMOS": {"https://evmos-mainnet.gateway.pokt.network/v1/lb/627586ddea1b320039c95205"},                                                         // 9001   Evmos
+	"TUS":   {"https://avax-cra-rpc.gateway.pokt.network"},                                                                                         // 73772  Swimmer Network
+}
+
 func WriteCarFilesToFiles(carFiles []*libmodel.FileDesc, outputDir, jsonFilename, csvFileName string) (*string, error) {
 	err := os.MkdirAll(outputDir, os.ModePerm)
 	if err != nil {

--- a/command/deal.go
+++ b/command/deal.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/filswan/go-swan-lib/client/web"
 	"path/filepath"
 	"strings"
 	"time"
@@ -66,7 +67,7 @@ func GetCmdDeal(outputDir *string, minerFids, metadataJsonPath, metadataCsvPath 
 	if !utils.IsStrEmpty(outputDir) {
 		cmdDeal.OutputDir = *outputDir
 	} else {
-		cmdDeal.OutputDir = filepath.Join(config.GetConfig().Sender.OutputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
+		cmdDeal.OutputDir = filepath.Join(*outputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
 	}
 
 	maxPriceStr := strings.Trim(config.GetConfig().Sender.MaxPrice, " ")
@@ -144,7 +145,7 @@ func (cmdDeal *CmdDeal) SendDeals() ([]*libmodel.FileDesc, error) {
 	}
 
 	if cmdDeal.VerifiedDeal {
-		isWalletVerified, err := swanClient.CheckDatacap(cmdDeal.SenderWallet)
+		isWalletVerified, err := cmdDeal.CheckDatacap(cmdDeal.SenderWallet)
 		if err != nil {
 			logs.GetLogger().Error(err)
 			return nil, err
@@ -272,4 +273,34 @@ func (cmdDeal *CmdDeal) sendDeals2Miner(taskName string, outputDir string, fileD
 	}
 
 	return fileDescs, err
+}
+
+func (cmdDeal *CmdDeal) CheckDatacap(address string) (bool, error) {
+
+	var params []interface{}
+	params = append(params, address)
+	params = append(params, []interface{}{})
+
+	jsonRpcParams := lotus.LotusJsonRpcParams{
+		JsonRpc: lotus.LOTUS_JSON_RPC_VERSION,
+		Method:  "Filecoin.StateVerifiedClientStatus",
+		Params:  params,
+		Id:      lotus.LOTUS_JSON_RPC_ID,
+	}
+	response, err := web.HttpPostNoToken(cmdDeal.LotusClientApiUrl, jsonRpcParams)
+	if err != nil {
+		logs.GetLogger().Error(err)
+		return false, err
+	}
+
+	result := utils.GetFieldStrFromJson(response, "result")
+	if result == "" {
+		logs.GetLogger().Error("no response from:", cmdDeal.LotusClientApiUrl)
+		return false, err
+	}
+
+	if string(result) == "0" {
+		return false, nil
+	}
+	return true, nil
 }

--- a/command/gocar.go
+++ b/command/gocar.go
@@ -208,6 +208,7 @@ func (cmdGoCar *CmdGoCar) createFilesDescFromManifest() ([]*libmodel.FileDesc, e
 		fileDesc := libmodel.FileDesc{}
 		fileDesc.PayloadCid = fields[0]
 		fileDesc.CarFileName = fileDesc.PayloadCid + ".car"
+		fileDesc.CarFileUrl = fileDesc.CarFileName
 		fileDesc.CarFilePath = filepath.Join(cmdGoCar.OutputDir, fileDesc.CarFileName)
 		fileDesc.PieceCid = fields[2]
 		fileDesc.CarFileSize = utils.GetInt64FromStr(fields[3])

--- a/command/ipfscar.go
+++ b/command/ipfscar.go
@@ -120,6 +120,7 @@ func (cmdIpfsCar *CmdIpfsCar) CreateIpfsCarFiles() ([]*libmodel.FileDesc, error)
 	fileDesc.SourceFilePath = cmdIpfsCar.InputDir
 	fileDesc.SourceFileSize = srcFileSize
 	fileDesc.CarFileName = carFileName
+	fileDesc.CarFileUrl = fileDesc.CarFileName
 	fileDesc.CarFilePath = carFilePath
 
 	if cmdIpfsCar.ImportFlag {

--- a/command/ipfscar.go
+++ b/command/ipfscar.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/filswan/go-swan-lib/client/lotus"
 	"io/ioutil"
 	"path/filepath"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/codingsince1985/checksum"
 	"github.com/filswan/go-swan-client/config"
 	"github.com/filswan/go-swan-lib/client/ipfs"
-	"github.com/filswan/go-swan-lib/client/lotus"
 	"github.com/filswan/go-swan-lib/logs"
 	libmodel "github.com/filswan/go-swan-lib/model"
 	"github.com/filswan/go-swan-lib/utils"
@@ -23,28 +23,30 @@ type CmdIpfsCar struct {
 	InputDir                  string //required
 	GenerateMd5               bool   //required
 	IpfsServerUploadUrlPrefix string //required
+	ImportFlag                bool
 }
 
-func GetCmdIpfsCar(inputDir string, outputDir *string) *CmdIpfsCar {
+func GetCmdIpfsCar(inputDir string, outputDir *string, importFlag bool) *CmdIpfsCar {
 	cmdIpfsCar := &CmdIpfsCar{
 		LotusClientApiUrl:         config.GetConfig().Lotus.ClientApiUrl,
 		LotusClientAccessToken:    config.GetConfig().Lotus.ClientAccessToken,
 		InputDir:                  inputDir,
 		GenerateMd5:               config.GetConfig().Sender.GenerateMd5,
 		IpfsServerUploadUrlPrefix: config.GetConfig().IpfsServer.UploadUrlPrefix,
+		ImportFlag:                importFlag,
 	}
 
 	if !utils.IsStrEmpty(outputDir) {
 		cmdIpfsCar.OutputDir = *outputDir
 	} else {
-		cmdIpfsCar.OutputDir = filepath.Join(config.GetConfig().Sender.OutputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
+		cmdIpfsCar.OutputDir = filepath.Join(*outputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
 	}
 
 	return cmdIpfsCar
 }
 
-func CreateIpfsCarFilesByConfig(inputDir string, outputDir *string) ([]*libmodel.FileDesc, error) {
-	cmdIpfsCar := GetCmdIpfsCar(inputDir, outputDir)
+func CreateIpfsCarFilesByConfig(inputDir string, outputDir *string, importFlag bool) ([]*libmodel.FileDesc, error) {
+	cmdIpfsCar := GetCmdIpfsCar(inputDir, outputDir, importFlag)
 	fileDescs, err := cmdIpfsCar.CreateIpfsCarFiles()
 	if err != nil {
 		logs.GetLogger().Error(err)
@@ -85,12 +87,6 @@ func (cmdIpfsCar *CmdIpfsCar) CreateIpfsCarFiles() ([]*libmodel.FileDesc, error)
 		return nil, err
 	}
 
-	lotusClient, err := lotus.LotusGetClient(cmdIpfsCar.LotusClientApiUrl, cmdIpfsCar.LotusClientAccessToken)
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return nil, err
-	}
-
 	logs.GetLogger().Info("Creating car file for ", cmdIpfsCar.InputDir)
 	srcFileCids := []string{}
 	var srcFileSize int64 = int64(0)
@@ -126,22 +122,36 @@ func (cmdIpfsCar *CmdIpfsCar) CreateIpfsCarFiles() ([]*libmodel.FileDesc, error)
 	fileDesc.CarFileName = carFileName
 	fileDesc.CarFilePath = carFilePath
 
-	pieceCid, err := lotusClient.LotusClientCalcCommP(fileDesc.CarFilePath)
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return nil, err
+	if cmdIpfsCar.ImportFlag {
+		lotusClient, err := lotus.LotusGetClient(cmdIpfsCar.LotusClientApiUrl, cmdIpfsCar.LotusClientAccessToken)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+
+		pieceCid, err := lotusClient.LotusClientCalcCommP(fileDesc.CarFilePath)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+		fileDesc.PieceCid = *pieceCid
+
+		dataCid, err := lotusClient.LotusClientImport(fileDesc.CarFilePath, true)
+		if err != nil {
+			err := fmt.Errorf("failed to import car file to lotus client")
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+		fileDesc.PayloadCid = *dataCid
+	} else {
+		dataCid, pieceCid, _, err := CalculateValueByCarFile(fileDesc.CarFilePath, true, true)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+		fileDesc.PayloadCid = dataCid
+		fileDesc.PieceCid = pieceCid
 	}
-
-	fileDesc.PieceCid = *pieceCid
-
-	dataCid, err := lotusClient.LotusClientImport(fileDesc.CarFilePath, true)
-	if err != nil {
-		err := fmt.Errorf("failed to import car file to lotus client")
-		logs.GetLogger().Error(err)
-		return nil, err
-	}
-
-	fileDesc.PayloadCid = *dataCid
 
 	fileDesc.CarFileSize = utils.GetFileSize(fileDesc.CarFilePath)
 

--- a/command/ipfscmdcar.go
+++ b/command/ipfscmdcar.go
@@ -100,6 +100,7 @@ func (cmdIpfsCmdCar *CmdIpfsCmdCar) CreateIpfsCmdCarFiles() ([]*libmodel.FileDes
 	fileDesc.SourceFilePath = cmdIpfsCmdCar.InputDir
 	fileDesc.SourceFileSize = *srcFileSize
 	fileDesc.CarFileName = carFileName
+	fileDesc.CarFileUrl = fileDesc.CarFileName
 	fileDesc.CarFilePath = carFilePath
 
 	if cmdIpfsCmdCar.ImportFlag {

--- a/command/ipfscmdcar.go
+++ b/command/ipfscmdcar.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/filswan/go-swan-lib/client/lotus"
 	"path/filepath"
 	"strings"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/codingsince1985/checksum"
 	"github.com/filswan/go-swan-client/config"
 	"github.com/filswan/go-swan-lib/client"
-	"github.com/filswan/go-swan-lib/client/lotus"
 	"github.com/filswan/go-swan-lib/logs"
 	libmodel "github.com/filswan/go-swan-lib/model"
 	"github.com/filswan/go-swan-lib/utils"
@@ -22,27 +22,29 @@ type CmdIpfsCmdCar struct {
 	OutputDir              string //required
 	InputDir               string //required
 	GenerateMd5            bool   //required
+	ImportFlag             bool
 }
 
-func GetCmdIpfsCmdCar(inputDir string, outputDir *string) *CmdIpfsCmdCar {
+func GetCmdIpfsCmdCar(inputDir string, outputDir *string, importFlag bool) *CmdIpfsCmdCar {
 	cmdIpfsCmdCar := &CmdIpfsCmdCar{
 		LotusClientApiUrl:      config.GetConfig().Lotus.ClientApiUrl,
 		LotusClientAccessToken: config.GetConfig().Lotus.ClientAccessToken,
 		InputDir:               inputDir,
 		GenerateMd5:            config.GetConfig().Sender.GenerateMd5,
+		ImportFlag:             importFlag,
 	}
 
 	if !utils.IsStrEmpty(outputDir) {
 		cmdIpfsCmdCar.OutputDir = *outputDir
 	} else {
-		cmdIpfsCmdCar.OutputDir = filepath.Join(config.GetConfig().Sender.OutputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
+		cmdIpfsCmdCar.OutputDir = filepath.Join(*outputDir, time.Now().Format("2006-01-02_15:04:05")) + "_" + uuid.NewString()
 	}
 
 	return cmdIpfsCmdCar
 }
 
-func CreateIpfsCmdCarFilesByConfig(inputDir string, outputDir *string) ([]*libmodel.FileDesc, error) {
-	cmdIpfsCmdCar := GetCmdIpfsCmdCar(inputDir, outputDir)
+func CreateIpfsCmdCarFilesByConfig(inputDir string, outputDir *string, importFlag bool) ([]*libmodel.FileDesc, error) {
+	cmdIpfsCmdCar := GetCmdIpfsCmdCar(inputDir, outputDir, importFlag)
 	fileDescs, err := cmdIpfsCmdCar.CreateIpfsCmdCarFiles()
 	if err != nil {
 		logs.GetLogger().Error(err)
@@ -77,12 +79,6 @@ func (cmdIpfsCmdCar *CmdIpfsCmdCar) CreateIpfsCmdCarFiles() ([]*libmodel.FileDes
 		return nil, err
 	}
 
-	lotusClient, err := lotus.LotusGetClient(cmdIpfsCmdCar.LotusClientApiUrl, cmdIpfsCmdCar.LotusClientAccessToken)
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return nil, err
-	}
-
 	logs.GetLogger().Info("Creating car file for ", cmdIpfsCmdCar.InputDir)
 	carFileName := filepath.Base(cmdIpfsCmdCar.InputDir) + ".car"
 	carFilePath := filepath.Join(cmdIpfsCmdCar.OutputDir, carFileName)
@@ -106,22 +102,36 @@ func (cmdIpfsCmdCar *CmdIpfsCmdCar) CreateIpfsCmdCarFiles() ([]*libmodel.FileDes
 	fileDesc.CarFileName = carFileName
 	fileDesc.CarFilePath = carFilePath
 
-	pieceCid, err := lotusClient.LotusClientCalcCommP(fileDesc.CarFilePath)
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return nil, err
+	if cmdIpfsCmdCar.ImportFlag {
+		lotusClient, err := lotus.LotusGetClient(cmdIpfsCmdCar.LotusClientApiUrl, cmdIpfsCmdCar.LotusClientAccessToken)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+
+		pieceCid, err := lotusClient.LotusClientCalcCommP(fileDesc.CarFilePath)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+		fileDesc.PieceCid = *pieceCid
+
+		dataCid, err := lotusClient.LotusClientImport(fileDesc.CarFilePath, true)
+		if err != nil {
+			err := fmt.Errorf("failed to import car file to lotus client")
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+		fileDesc.PayloadCid = *dataCid
+	} else {
+		dataCid, pieceCid, _, err := CalculateValueByCarFile(fileDesc.CarFilePath, true, true)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return nil, err
+		}
+		fileDesc.PayloadCid = dataCid
+		fileDesc.PieceCid = pieceCid
 	}
-
-	fileDesc.PieceCid = *pieceCid
-
-	dataCid, err := lotusClient.LotusClientImport(fileDesc.CarFilePath, true)
-	if err != nil {
-		err := fmt.Errorf("failed to import car file to lotus client")
-		logs.GetLogger().Error(err)
-		return nil, err
-	}
-
-	fileDesc.PayloadCid = *dataCid
 
 	fileDesc.CarFileSize = utils.GetFileSize(fileDesc.CarFilePath)
 

--- a/command/task.go
+++ b/command/task.go
@@ -23,43 +23,39 @@ import (
 )
 
 type CmdTask struct {
-	SwanApiUrl        string          //required when OfflineMode is false
-	SwanApiKey        string          //required when OfflineMode is false and SwanJwtToken is not provided
-	SwanAccessToken   string          //required when OfflineMode is false and SwanJwtToken is not provided
-	SwanToken         string          //required when OfflineMode is false and SwanApiKey & SwanAccessToken are not provided
-	LotusClientApiUrl string          //required
-	BidMode           int             //required
-	VerifiedDeal      bool            //required
-	OfflineMode       bool            //required
-	FastRetrieval     bool            //required
-	MaxPrice          decimal.Decimal //required
-	//StorageServerType          string          //required
-	//WebServerDownloadUrlPrefix string          //required only when StorageServerType is web server
-	ExpireDays           int    //required
-	GenerateMd5          bool   //required
-	Duration             int    //not necessary, when not provided use default value:1512000
-	OutputDir            string //required
-	InputDir             string //required
-	TaskName             string //not necessary, when not provided use default value:swan_task_xxxxxx
-	Dataset              string //not necessary
-	Description          string //not necessary
-	StartEpochHours      int    //required
-	SourceId             int    //required
-	MaxAutoBidCopyNumber int    //required only for public autobid deal
+	SwanApiUrl           string          //required when OfflineMode is false
+	SwanApiKey           string          //required when OfflineMode is false and SwanJwtToken is not provided
+	SwanAccessToken      string          //required when OfflineMode is false and SwanJwtToken is not provided
+	SwanToken            string          //required when OfflineMode is false and SwanApiKey & SwanAccessToken are not provided
+	LotusClientApiUrl    string          //required
+	BidMode              int             //required
+	VerifiedDeal         bool            //required
+	OfflineMode          bool            //required
+	FastRetrieval        bool            //required
+	MaxPrice             decimal.Decimal //required
+	ExpireDays           int             //required
+	GenerateMd5          bool            //required
+	Duration             int             //not necessary, when not provided use default value:1512000
+	OutputDir            string          //required
+	InputDir             string          //required
+	TaskName             string          //not necessary, when not provided use default value:swan_task_xxxxxx
+	Dataset              string          //not necessary
+	Description          string          //not necessary
+	StartEpochHours      int             //required
+	SourceId             int             //required
+	MaxAutoBidCopyNumber int             //required only for public autobid deal
 }
 
 func GetCmdTask(inputDir string, outputDir *string, taskName, dataset, description string, bidMode, maxCopyNumber int) *CmdTask {
 	cmdTask := &CmdTask{
-		SwanApiUrl:        config.GetConfig().Main.SwanApiUrl,
-		SwanApiKey:        config.GetConfig().Main.SwanApiKey,
-		SwanAccessToken:   config.GetConfig().Main.SwanAccessToken,
-		LotusClientApiUrl: config.GetConfig().Lotus.ClientApiUrl,
-		BidMode:           bidMode,
-		VerifiedDeal:      config.GetConfig().Sender.VerifiedDeal,
-		OfflineMode:       config.GetConfig().Sender.OfflineMode,
-		FastRetrieval:     config.GetConfig().Sender.FastRetrieval,
-		//StorageServerType:          config.GetConfig().Main.StorageServerType,
-		//WebServerDownloadUrlPrefix: config.GetConfig().WebServer.DownloadUrlPrefix,
+		SwanApiUrl:           config.GetConfig().Main.SwanApiUrl,
+		SwanApiKey:           config.GetConfig().Main.SwanApiKey,
+		SwanAccessToken:      config.GetConfig().Main.SwanAccessToken,
+		LotusClientApiUrl:    config.GetConfig().Lotus.ClientApiUrl,
+		BidMode:              bidMode,
+		VerifiedDeal:         config.GetConfig().Sender.VerifiedDeal,
+		OfflineMode:          config.GetConfig().Sender.OfflineSwan,
+		FastRetrieval:        config.GetConfig().Sender.FastRetrieval,
 		ExpireDays:           config.GetConfig().Sender.ExpireDays,
 		GenerateMd5:          config.GetConfig().Sender.GenerateMd5,
 		Duration:             config.GetConfig().Sender.Duration,
@@ -231,10 +227,6 @@ func (cmdTask *CmdTask) CreateTask(cmdDeal *CmdDeal) (*string, []*libmodel.FileD
 		fileDesc.Uuid = task.Uuid
 		fileDesc.StartEpoch = &startEpoch
 		fileDesc.SourceId = &cmdTask.SourceId
-
-		//if cmdTask.StorageServerType == libconstants.STORAGE_SERVER_TYPE_WEB_SERVER {
-		//	fileDesc.CarFileUrl = utils.UrlJoin(cmdTask.WebServerDownloadUrlPrefix, fileDesc.CarFileName)
-		//}
 
 		if cmdTask.GenerateMd5 {
 			if fileDesc.SourceFileMd5 == "" && utils.IsFileExistsFullPath(fileDesc.SourceFilePath) {

--- a/command/upload.go
+++ b/command/upload.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/filswan/go-swan-client/config"
 
-	libconstants "github.com/filswan/go-swan-lib/constants"
 	"github.com/filswan/go-swan-lib/logs"
 	"github.com/filswan/go-swan-lib/utils"
 )
 
 type CmdUpload struct {
-	StorageServerType           string //required
 	IpfsServerDownloadUrlPrefix string //required only when upload to ipfs server
 	IpfsServerUploadUrlPrefix   string //required only when upload to ipfs server
 	InputDir                    string //required
@@ -22,7 +20,6 @@ type CmdUpload struct {
 
 func GetCmdUpload(inputDir string) *CmdUpload {
 	cmdUpload := &CmdUpload{
-		StorageServerType:           config.GetConfig().Main.StorageServerType,
 		IpfsServerDownloadUrlPrefix: config.GetConfig().IpfsServer.DownloadUrlPrefix,
 		IpfsServerUploadUrlPrefix:   config.GetConfig().IpfsServer.UploadUrlPrefix,
 		InputDir:                    inputDir,
@@ -50,11 +47,6 @@ func (cmdUpload *CmdUpload) UploadCarFiles() ([]*libmodel.FileDesc, error) {
 		return nil, err
 	}
 
-	if cmdUpload.StorageServerType == libconstants.STORAGE_SERVER_TYPE_WEB_SERVER {
-		logs.GetLogger().Info("Please upload car files to web server manually.")
-		return nil, nil
-	}
-
 	fileDescs, err := ReadFileDescsFromJsonFile(cmdUpload.InputDir, JSON_FILE_NAME_CAR_UPLOAD)
 	if err != nil {
 		logs.GetLogger().Error(err)
@@ -66,7 +58,6 @@ func (cmdUpload *CmdUpload) UploadCarFiles() ([]*libmodel.FileDesc, error) {
 		logs.GetLogger().Error(err)
 		return nil, err
 	}
-
 	uploadUrl := utils.UrlJoin(cmdUpload.IpfsServerUploadUrlPrefix, "api/v0/add?stream-channels=true&pin=true")
 	for _, fileDesc := range fileDescs {
 		logs.GetLogger().Info("Uploading car file:", fileDesc.CarFilePath, " to:", uploadUrl)

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,6 @@ import (
 type Configuration struct {
 	Lotus      lotus      `toml:"lotus"`
 	Main       main       `toml:"main"`
-	WebServer  webServer  `toml:"web_server"`
 	IpfsServer ipfsServer `toml:"ipfs_server"`
 	Sender     sender     `toml:"sender"`
 }
@@ -30,19 +29,13 @@ type main struct {
 	StorageServerType string `toml:"storage_server_type"`
 }
 
-type webServer struct {
-	DownloadUrlPrefix string `toml:"download_url_prefix"`
-}
-
 type ipfsServer struct {
 	DownloadUrlPrefix string `toml:"download_url_prefix"`
 	UploadUrlPrefix   string `toml:"upload_url_prefix"`
 }
 
 type sender struct {
-	BidMode               int           `toml:"bid_mode"`
 	OfflineMode           bool          `toml:"offline_mode"`
-	OutputDir             string        `toml:"output_dir"`
 	VerifiedDeal          bool          `toml:"verified_deal"`
 	FastRetrieval         bool          `toml:"fast_retrieval"`
 	SkipConfirmation      bool          `toml:"skip_confirmation"`
@@ -51,10 +44,7 @@ type sender struct {
 	MaxPrice              string        `toml:"max_price"`
 	StartEpochHours       int           `toml:"start_epoch_hours"`
 	ExpireDays            int           `toml:"expire_days"`
-	GocarFileSizeLimit    int64         `toml:"gocar_file_size_limit"`
-	GocarFolderBased      bool          `toml:"gocar_folder_based"`
 	Duration              int           `toml:"duration"`
-	MaxAutoBidCopyNumber  int           `toml:"max_auto_bid_copy_number"`
 	StartDealTimeInterval time.Duration `toml:"start_deal_time_interval"`
 }
 
@@ -87,7 +77,6 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 	requiredFields := [][]string{
 		{"lotus"},
 		{"main"},
-		{"web_server"},
 		{"ipfs_server"},
 		{"sender"},
 
@@ -97,16 +86,11 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"main", "api_url"},
 		{"main", "api_key"},
 		{"main", "access_token"},
-		{"main", "storage_server_type"},
-
-		{"web_server", "download_url_prefix"},
 
 		{"ipfs_server", "download_url_prefix"},
 		{"ipfs_server", "upload_url_prefix"},
 
-		{"sender", "bid_mode"},
 		{"sender", "offline_mode"},
-		{"sender", "output_dir"},
 		{"sender", "verified_deal"},
 		{"sender", "fast_retrieval"},
 		{"sender", "skip_confirmation"},
@@ -115,10 +99,7 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"sender", "max_price"},
 		{"sender", "start_epoch_hours"},
 		{"sender", "expire_days"},
-		{"sender", "gocar_file_size_limit"},
-		{"sender", "gocar_folder_based"},
 		{"sender", "duration"},
-		{"sender", "max_auto_bid_copy_number"},
 		{"sender", "start_deal_time_interval"},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,10 +23,9 @@ type lotus struct {
 }
 
 type main struct {
-	SwanApiUrl        string `toml:"api_url"`
-	SwanApiKey        string `toml:"api_key"`
-	SwanAccessToken   string `toml:"access_token"`
-	StorageServerType string `toml:"storage_server_type"`
+	SwanApiUrl      string `toml:"api_url"`
+	SwanApiKey      string `toml:"api_key"`
+	SwanAccessToken string `toml:"access_token"`
 }
 
 type ipfsServer struct {
@@ -35,7 +34,7 @@ type ipfsServer struct {
 }
 
 type sender struct {
-	OfflineMode           bool          `toml:"offline_mode"`
+	OfflineSwan           bool          `toml:"offline_swan"`
 	VerifiedDeal          bool          `toml:"verified_deal"`
 	FastRetrieval         bool          `toml:"fast_retrieval"`
 	SkipConfirmation      bool          `toml:"skip_confirmation"`
@@ -90,7 +89,7 @@ func requiredFieldsAreGiven(metaData toml.MetaData) bool {
 		{"ipfs_server", "download_url_prefix"},
 		{"ipfs_server", "upload_url_prefix"},
 
-		{"sender", "offline_mode"},
+		{"sender", "offline_swan"},
 		{"sender", "verified_deal"},
 		{"sender", "fast_retrieval"},
 		{"sender", "skip_confirmation"},

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -4,7 +4,7 @@ client_access_token = ""                       # Access token of lotus client we
 
 [main]
 api_url = "https://go-swan-server.filswan.com" # Swan API address. For Swan production, it is `https://go-swan-server.filswan.com`. It can be ignored if `[sender].offline_swan=true`
-api_key = "" # Swan API key. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
+api_key = ""                                   # Swan API key. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
 access_token = ""                              # Swan API access token. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
 
 [ipfs_server]

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -1,25 +1,25 @@
 [lotus]
 client_api_url = "http://[ip]:[port]/rpc/v0"   # Url of lotus client web api, generally the [port] is 1234
-client_access_token = ""   # Access token of lotus client web api, it should have admin access right
+client_access_token = ""                       # Access token of lotus client web api, it should have admin access right
 
 [main]
-api_url = "https://go-swan-server.filswan.com"
-api_key = ""
-access_token = ""
+api_url = "https://go-swan-server.filswan.com" # Swan API address. For Swan production, it is `https://go-swan-server.filswan.com`. It can be ignored if `[sender].offline_swan=true`
+api_key = "" # Swan API key. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
+access_token = ""                              # Swan API access token. Acquire from [Swan Platform](https://console.filswan.com/#/dashboard) -> "My Profile"->"Developer Settings". It can be ignored if `[sender].offline_mode=true`.
 
 [ipfs_server]
-download_url_prefix = "http://[ip]:[port]"
-upload_url_prefix = "http://[ip]:[port]"
+download_url_prefix = "http://[ip]:[port]"     # IPFS server url prefix. Store CAR files for downloading by storage provider. The downloading url will be `[download_url_prefix]/ipfs/[dataCID]`
+upload_url_prefix = "http://[ip]:[port]"       # IPFS server url for uploading files
 
 [sender]
-offline_mode = false
-verified_deal = true
-fast_retrieval = true
-skip_confirmation = false
-generate_md5 = false
-wallet = ""
-max_price = "0"
-start_epoch_hours = 96
-expire_days = 4
-duration = 1051200    # Duration is expressed in blocks (1 block is equivalent to 30s).
-start_deal_time_interval = 500 # lotus proposes a deal with a miner the time interval. default: 500ms
+offline_swan = false                           # Whether to create a task on [Swan Platform](https://console.filswan.com/#/dashboard), when set to true, only generate metadata for Storage Providers to import deals. 
+verified_deal = true                           # Whether deals in the task are going to be sent as verified or not
+fast_retrieval = true                          # Whether deals in the task are available for fast-retrieval or not
+skip_confirmation = false                      # Whether to skip manual confirmation of each deal before sending
+generate_md5 = false                           # Whether to generate md5 for each car file and source file(resource consuming)
+wallet = ""                                    # Wallet used for sending offline deals
+max_price = "0"                                # Max price willing to pay per GiB/epoch for offline deals
+start_epoch_hours = 96                         # Specify hours that the deal should after at (default 96 hours)
+expire_days = 4                                # Specify days that the deal will expire after (default 4 days) 
+duration = 1512000                             # How long the Storage Providers should store the data for, in blocks(30s/block), default 1512000.
+start_deal_time_interval = 500                 # The interval between two deals sent, default: 500ms

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -6,19 +6,13 @@ client_access_token = ""   # Access token of lotus client web api, it should hav
 api_url = "https://go-swan-server.filswan.com"
 api_key = ""
 access_token = ""
-storage_server_type = "ipfs server"
-
-[web_server]
-download_url_prefix = "https://nbai.io:443/download"
 
 [ipfs_server]
 download_url_prefix = "http://[ip]:[port]"
 upload_url_prefix = "http://[ip]:[port]"
 
 [sender]
-bid_mode = 1     # 1: auto bid, 0: manual bid, 2: not use bid, when creating task, set miners and sending deals
 offline_mode = false
-output_dir = "/tmp/tasks"
 verified_deal = true
 fast_retrieval = true
 skip_confirmation = false
@@ -27,8 +21,5 @@ wallet = ""
 max_price = "0"
 start_epoch_hours = 96
 expire_days = 4
-gocar_file_size_limit = 8589934592
-gocar_folder_based = false
 duration = 1051200    # Duration is expressed in blocks (1 block is equivalent to 30s).
-max_auto_bid_copy_number = 8 # max copy number you want to send
 start_deal_time_interval = 500 # lotus proposes a deal with a miner the time interval. default: 500ms

--- a/document/command_struct.md
+++ b/document/command_struct.md
@@ -18,6 +18,7 @@ type CmdCar struct {
 	OutputDir              string //required
 	InputDir               string //required
 	GenerateMd5            bool   //required
+	ImportFlag             bool
 }
 ```
 
@@ -31,6 +32,8 @@ type CmdGoCar struct {
 	GenerateMd5            bool   //required
 	GocarFileSizeLimit     int64  //required
 	GocarFolderBased       bool   //required
+	Parallel               int
+	ImportFlag             bool
 }
 ```
 
@@ -43,6 +46,7 @@ type CmdIpfsCar struct {
 	InputDir                  string //required
 	GenerateMd5               bool   //required
 	IpfsServerUploadUrlPrefix string //required
+	ImportFlag                bool
 }
 ```
 
@@ -55,16 +59,15 @@ type CmdIpfsCmdCar struct {
 	OutputDir              string //required
 	InputDir               string //required
 	GenerateMd5            bool   //required
+	ImportFlag             bool
 }
 ```
 
 ## CmdUpload
 ```shell
 type CmdUpload struct {
-	StorageServerType           string //required
 	IpfsServerDownloadUrlPrefix string //required only when upload to ipfs server
 	IpfsServerUploadUrlPrefix   string //required only when upload to ipfs server
-	OutputDir                   string //invalid
 	InputDir                    string //required
 }
 ```
@@ -82,8 +85,6 @@ type CmdTask struct {
 	OfflineMode                bool            //required
 	FastRetrieval              bool            //required
 	MaxPrice                   decimal.Decimal //required
-	StorageServerType          string          //required
-	WebServerDownloadUrlPrefix string          //required only when StorageServerType is web server
 	ExpireDays                 int             //required
 	GenerateMd5                bool            //required
 	Duration                   int             //not necessary, when not provided use default value:1512000

--- a/document/rpc-cmd-example.md
+++ b/document/rpc-cmd-example.md
@@ -1,0 +1,116 @@
+### 1. Ethereum Mainnet
+* Chain explorer: https://etherscan.io
+* JSON-RPC api documentation: https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods
+* Example:
+```
+swan-client rpc height --chain ETH
+swan-client rpc balance --chain ETH --address 0x29D5527CaA78f1946a409FA6aCaf14A0a4A0274b
+```
+
+### 2. Binance Smart Chain Mainnet
+* Chain explorer: https://bscscan.com
+* JSON-RPC api documentation: https://documenter.getpostman.com/view/4117254/ethereum-json-rpc/RVu7CT5J?version=latest
+* Example:
+```shell
+swan-client rpc height --chain BNB
+swan-client rpc balance --chain BNB --address 0x4430b3230294D12c6AB2aAC5C2cd68E80B16b581
+```
+
+### 3. Avalanche C-Chain
+* Chain explorer: https://subnets.avax.network/c-chain
+* JSON-RPC api documentation: https://ethereum.org/en/developers/docs/apis/json-rpc/
+* Example:
+```shell
+swan-client rpc height --chain AVAX
+swan-client rpc balance --chain AVAX --address 0x8CD98FF48831aa8864314ae8f41337FaE9941C8D
+```
+
+### 4. Polygon Mainnet
+* Chain explorer: https://polygonscan.com
+* JSON-RPC api documentation: https://wiki.polygon.technology/docs/edge/get-started/json-rpc-commands/
+* Example:
+```shell
+swan-client rpc height --chain MATIC
+swan-client rpc balance --chain MATIC --address 0xFb3494ecdf2A08c47F1F6A554E8dDFc7Ca259C0e
+```
+
+### 5. Fantom Opera
+* Chain explorer: https://explorer.fantom.network
+* JSON-RPC api documentation: https://docs.fantom.foundation/api/blockvision-indexing-and-querying-api
+* Example:
+```shell
+swan-client rpc height --chain FTM
+swan-client rpc balance --chain FTM --address 0xbc533f161a0e8564ce343cb18b1662ef9080d214 
+```
+
+### 6. Gnosis Chain
+* Chain explorer: https://blockscout.com/xdai/mainnet
+* JSON-RPC api documentation: https://docs.gnosischain.com/tools/rpc
+* Example:
+```shell
+swan-client rpc height --chain xDAI
+swan-client rpc balance --chain xDAI --address 0x64DcfC61A25A2A9BDcFEe3CfAe0A3BefdEffAB86
+```
+
+### 7. IoTeX Network Mainnet
+* Chain explorer: https://iotexscan.io
+* JSON-RPC api documentation: https://docs.iotex.io/reference/babel-web3-api
+* Example:
+```shell
+swan-client rpc height --chain IOTX
+swan-client rpc balance --chain IOTX --address 0xfdf9609f5ee6f3104d48f60d3ae6be0c9fc424d9   # io1lhukp867ume3qn2g7cxn4e47pj0ugfxeqj7nm8
+```
+
+### 8. Harmony Mainnet Shard 0
+* Chain explorer: https://explorer.pops.one 
+* JSON-RPC api documentation: https://api.hmny.io/#intro
+* Example:
+```shell
+swan-client rpc height --chain ONE
+swan-client rpc balance --chain ONE --address one1fys8axmefrgzurzazzytsx844ew8qxv3kygurm   # one1fys8axmefrgzurzazzytsx844ew8qxv3kygurm
+```
+
+### 9. Boba Network
+* Chain explorer: https://bobascan.com
+* JSON-RPC api documentation: https://docs.boba.network/for-developers/json-rpc-api
+* Example:
+```shell
+swan-client rpc height --chain BOBA
+swan-client rpc balance --chain BOBA --address 0x400dE12cDD8Ed124E9134B12Bb43be0b23C9D883
+```
+
+### 10. Fuse Mainnet
+* Chain explorer: https://explorer.fuse.io
+* JSON-RPC api documentation: https://explorer.fuse.io/eth-rpc-api-docs
+* Example:
+```shell
+swan-client rpc height --chain FUSE
+swan-client rpc balance --chain FUSE --address 0xC3b0b197C3B022E161B8299E01dC2cB4485372dc
+```
+
+### 11. DFK Chain
+* Chain explorer: https://avascan.info/blockchain/dfk/home
+* JSON-RPC api documentation: https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods
+* Example:
+```shell
+swan-client rpc height --chain JEWEL
+swan-client rpc balance --chain JEWEL --address 0x171812321D6dC353295f132eea26EB4036A47f65
+```
+
+### 12. Evmos
+* Chain explorer: https://evm.evmos.org/
+* JSON-RPC api documentation: https://evm.evmos.org/eth-rpc-api-docs
+* Example:
+```shell
+swan-client rpc height --chain EVMOS
+swan-client rpc balance --chain EVMOS --address 0x5eF06C99E3a2ED1b2E6306a3B3f6b6dBD928A64A
+```
+
+### 13. Swimmer Network
+* Chain explorer: https://avascan.info/blockchain/swimmer/txs
+* JSON-RPC api documentation: https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods
+* Example:
+```shell
+swan-client rpc height --chain TUS
+swan-client rpc balance --chain TUS --address 0xF623C65b743Ae791A4d94ad2F5853E3781c79224
+```

--- a/document/swan-client.md
+++ b/document/swan-client.md
@@ -1,0 +1,198 @@
+# swan-client
+```
+NAME:
+   swan-client - A PiB level data onboarding tool for Filecoin Network
+
+USAGE:
+   swan-client [global options] command [command options] [arguments...]
+
+VERSION:
+   2.0.0
+
+COMMANDS:
+   generate-car  Generate CAR files from a file or directory
+   upload        Upload CAR file to ipfs server
+   task          Send task to swan
+   deal          Send manual-bid deal
+   commP         Calculate the dataCid, pieceCid, pieceSize of the CAR file
+
+GLOBAL OPTIONS:
+   --help, -h     show help (default: false)
+   --version, -v  print the version (default: false)
+```
+
+## swan-client generate-car
+```
+NAME:
+   swan-client generate-car - Generate CAR files from a file or directory
+
+USAGE:
+   swan-client generate-car command [command options] [arguments...]
+
+COMMANDS:
+   graphsplit  Use go-graphsplit tools
+   lotus       Use lotus api to generate CAR file
+   ipfs        Use ipfs api to generate CAR file
+   ipfs-car    use the ipfs-car command to generate the CAR file
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```
+
+### swan-client generate-car lotus
+```
+NAME:
+   swan-client generate-car lotus - Use lotus api to generate CAR file
+
+USAGE:
+   swan-client generate-car lotus [command options] [inputPath]
+
+OPTIONS:
+   --input-dir value, -i value  directory where source file(s) is(are) in.
+   --out-dir value, -o value    directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                     whether to import CAR file to lotus (default: true)
+   --help, -h                   show help (default: false)
+```
+
+### swan-client generate-car ipfs
+```
+NAME:
+   swan-client generate-car ipfs - Use ipfs api to generate CAR file
+
+USAGE:
+   swan-client generate-car ipfs [command options] [inputPath]
+
+OPTIONS:
+   --input-dir value, -i value  directory where source file(s) is(are) in.
+   --out-dir value, -o value    directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                     whether to import CAR file to lotus (default: true)
+   --help, -h                   show help (default: false)
+```
+### swan-client generate-car ipfs-car
+```
+NAME:
+   swan-client generate-car ipfs - Use ipfs api to generate CAR file
+
+USAGE:
+   swan-client generate-car ipfs [command options] [inputPath]
+
+OPTIONS:
+   --input-dir value, -i value  directory where source file(s) is(are) in.
+   --out-dir value, -o value    directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                     whether to import CAR file to lotus (default: true)
+   --help, -h                   show help (default: false)
+```
+
+### swan-client generate-car graphsplit
+```
+NAME:
+   swan-client generate-car graphsplit - Use go-graphsplit tools
+
+USAGE:
+   swan-client generate-car graphsplit command [command options] [arguments...]
+
+COMMANDS:
+   car      Generate CAR files of the specified size
+   restore  Restore files from CAR files
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```
+
+#### swan-client generate-car graphsplit car
+```
+NAME:
+   swan-client generate-car graphsplit car - Generate CAR files of the specified size
+
+USAGE:
+   swan-client generate-car graphsplit car [command options] [inputPath]
+
+OPTIONS:
+   --input-dir value, -i value       directory where source file(s) is(are) in.
+   --out-dir value, -o value         directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --import                          whether to import CAR file to lotus (default: true)
+   --parallel value                  number goroutines run when building ipld nodes (default: 5)
+   --slice-size value, --size value  GiB of each piece (default: 16GiB) (default: 17179869184)
+   --parent-path                     specify graph parent path (default: false)
+   --help, -h                        show help (default: false)
+```
+
+#### swan-client generate-car graphsplit restore
+```
+NAME:
+   swan-client generate-car graphsplit restore - Restore files from CAR files
+
+USAGE:
+   swan-client generate-car graphsplit restore [command options] [inputPath]
+
+OPTIONS:
+   --out-dir value, -o value    directory where CAR file(s) will be generated. (default: "/tmp/tasks")
+   --input-dir value, -i value  specify source CAR path, directory or file
+   --parallel value             number goroutines run when building ipld nodes (default: 5)
+   --help, -h                   show help (default: false)
+```
+
+## swan-client upload
+```
+NAME:
+   swan-client upload - Upload CAR file to ipfs server
+
+USAGE:
+   swan-client upload [command options] [inputPath]
+
+OPTIONS:
+   --input-dir value, -i value  directory where source files are in.
+   --help, -h                   show help (default: false)
+```
+
+## swan-client task
+```
+NAME:
+   swan-client task - Send task to swan
+
+USAGE:
+   swan-client task [command options] [arguments...]
+
+OPTIONS:
+   --name value                          task name
+   --input-dir value, -i value           absolute path where the json or csv format source files
+   --out-dir value, -o value             directory where target files will in (default: "/tmp/tasks")
+   --auto-bid                            send the auto-bid task (default: false)
+   --manual-bid                          send the manual-bid task (default: false)
+   --miners value                        minerID is required when send private task (pass comma separated array of minerIDs)
+   --dataset value                       curated dataset
+   --description value, -d value         task description
+   --max-copy-number value, --max value  max copy numbers when send auto-bid or manual-bid task (default: 1)
+   --help, -h                            show help (default: false)
+
+```
+
+## swan-client deal
+```
+NAME:
+   swan-client deal - Send manual-bid deal
+
+USAGE:
+   swan-client deal [command options] [arguments...]
+
+OPTIONS:
+   --csv value                the CSV file path of deal metadata
+   --json value               the JSON file path of deal metadata
+   --out-dir value, -o value  directory where target files will in (default: "/tmp/tasks")
+   --miners value             minerID is required when send manual-bid task (pass comma separated array of minerIDs)
+   --help, -h                 show help (default: false)
+```
+
+## swan-client commP
+```
+NAME:
+   swan-client commP - Calculate the dataCid, pieceCid, pieceSize of the CAR file
+
+USAGE:
+   swan-client commP [command options] [inputPath]
+
+OPTIONS:
+   --car-path value  absolute path to the car file
+   --piece-cid       whether to generate the pieceCid flag (default: false)
+   --help, -h        show help (default: false)
+```

--- a/document/swan-client.md
+++ b/document/swan-client.md
@@ -128,8 +128,8 @@ OPTIONS:
    --out-dir value, -o value         directory where CAR file(s) will be generated. (default: "/tmp/tasks")
    --import                          whether to import CAR file to lotus (default: true)
    --parallel value                  number goroutines run when building ipld nodes (default: 5)
-   --slice-size value, --size value  GiB of each piece (default: 16GiB) (default: 17179869184)
-   --parent-path                     specify graph parent path (default: false)
+   --slice-size value, --size value  bytes of each piece (default: 17179869184)
+   --parent-path                     generate CAR file based on whole folder (default: true)
    --help, -h                        show help (default: false)
 ```
 

--- a/document/swan-client.md
+++ b/document/swan-client.md
@@ -10,16 +10,32 @@ VERSION:
    2.0.0
 
 COMMANDS:
+   daemon        Start a API service process
    generate-car  Generate CAR files from a file or directory
    upload        Upload CAR file to ipfs server
    task          Send task to swan
    deal          Send manual-bid deal
    commP         Calculate the dataCid, pieceCid, pieceSize of the CAR file
+   rpc-api       RPC api proxy client of public chain
+   rpc           RPC proxy client of public chain
 
 GLOBAL OPTIONS:
    --help, -h     show help (default: false)
    --version, -v  print the version (default: false)
 ```
+
+## swan-client daemon
+```
+NAME:
+   swan-client daemon - Start a API service process
+
+USAGE:
+   swan-client daemon [command options] [arguments...]
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```
+
 
 ## swan-client generate-car
 ```
@@ -195,4 +211,62 @@ OPTIONS:
    --car-path value  absolute path to the car file
    --piece-cid       whether to generate the pieceCid flag (default: false)
    --help, -h        show help (default: false)
+```
+
+## swan-client rpc-api
+```
+NAME:
+   swan-client rpc-api - RPC api proxy client of public chain
+
+USAGE:
+   swan-client rpc-api [command options] [inputPath]
+
+OPTIONS:
+   --chain-id value          chainId as public chain.
+   --params value, -p value  the parameters of the request api must be in string json format.
+   --help, -h                show help (default: false)
+```
+
+## swan-client rpc
+```
+NAME:
+   swan-client rpc - RPC proxy client of public chain
+
+USAGE:
+   swan-client rpc command [command options] [arguments...]
+
+COMMANDS:
+   balance  Query current balance of public chain
+   height   Query current height of public chain
+   help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help (default: false)
+```
+### swan-client rpc balance
+```
+NAME:
+   swan-client rpc balance - Query current balance of public chain
+
+USAGE:
+   swan-client rpc balance [command options] [arguments...]
+
+OPTIONS:
+   --chain value, -c value    public chain. support ETH、BNB、AVAX、MATIC、FTM、xDAI、IOTX、ONE、BOBA、FUSE、JEWEL、EVMOS、TUS
+   --address value, -a value  wallet address
+   --help, -h                 show help (default: false)
+```
+
+### swan-client rpc height
+```
+NAME:
+   swan-client rpc height - Query current height of public chain
+
+USAGE:
+   swan-client rpc height [command options] [arguments...]
+
+OPTIONS:
+   --chain value, -c value  public chain. support ETH、BNB、AVAX、MATIC、FTM、xDAI、IOTX、ONE、BOBA、FUSE、JEWEL、EVMOS、TUS
+   --help, -h               show help (default: false)
+
 ```

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/filswan/go-swan-lib v0.2.132
 	github.com/google/uuid v1.3.0
 	github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d
+	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,15 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/codingsince1985/checksum v1.2.3
+	github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48
 	github.com/filedrive-team/go-graphsplit v0.4.1
 	github.com/filswan/go-swan-lib v0.2.132
 	github.com/google/uuid v1.3.0
+	github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d
+	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1
+	github.com/urfave/cli/v2 v2.3.0
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/codingsince1985/checksum v1.2.3
 	github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48
 	github.com/filedrive-team/go-graphsplit v0.4.1
-	github.com/filswan/go-swan-lib v0.2.132
+	github.com/filswan/go-swan-lib v0.2.133
 	github.com/google/uuid v1.3.0
 	github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/codingsince1985/checksum v1.2.3
 	github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48
 	github.com/filedrive-team/go-graphsplit v0.4.1
-	github.com/filswan/go-swan-lib v0.2.133
+	github.com/filswan/go-swan-lib v0.2.134
 	github.com/google/uuid v1.3.0
 	github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/go.sum
+++ b/go.sum
@@ -75,7 +75,9 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3 h1:HVTnpeuvF6Owjd5mniCL8DEXo7uYXdQEmOP4FJbV5tg=
 github.com/crackcomm/go-gitignore v0.0.0-20170627025303-887ab5e44cc3/go.mod h1:p1d6YEZWvFzEh4KLyvBcVSnrfNDDvK2zfK/4x2v/4pE=
@@ -806,7 +808,9 @@ github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qq
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -832,6 +836,7 @@ github.com/shurcooL/notifications v0.0.0-20181007000457-627ab5aea122/go.mod h1:b
 github.com/shurcooL/octicon v0.0.0-20181028054416-fa4f57f9efb2/go.mod h1:eWdoE5JD4R5UVWDucdOPg1g2fqQRq78IQa9zlOV1vpQ=
 github.com/shurcooL/reactions v0.0.0-20181006231557-f2e0b4ca5b82/go.mod h1:TCR1lToEk4d2s07G3XGfz2QrgHXg4RJBvjrOozvoWfk=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
@@ -880,6 +885,7 @@ github.com/tj/go-spin v1.1.0 h1:lhdWZsvImxvZ3q1C5OIB7d72DuOwP4O2NdBg9PyzNds=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/filecoin-project/specs-actors/v5 v5.0.0-20210512015452-4fe3889fff57 h
 github.com/filecoin-project/specs-actors/v5 v5.0.0-20210512015452-4fe3889fff57/go.mod h1:283yBMMUSDB2abcjP/hhrwTkhb9h3sfM6KGrep/ZlBI=
 github.com/filedrive-team/go-graphsplit v0.4.1 h1:TxzaOrJk/SDK8vfRFu/v46z/2Za5xSpoHC0UF135Oyk=
 github.com/filedrive-team/go-graphsplit v0.4.1/go.mod h1:W+ivPZK6/qa7I7n34DSLVMjTrszpeZv7UaP98QbQ++A=
-github.com/filswan/go-swan-lib v0.2.132 h1:wl9j5NXTyxmEhCelMJo/fEzzOnuXt96H9UKPrqOUjHw=
-github.com/filswan/go-swan-lib v0.2.132/go.mod h1:NRetmtZZRZ0L1OXri4rOUyjk5CrA0q8jvQelm+PeulU=
+github.com/filswan/go-swan-lib v0.2.134 h1:pzCM8cvfJmyY3Z/9Uwl7MQEY+RaI+E/7FTj+B4XalCQ=
+github.com/filswan/go-swan-lib v0.2.134/go.mod h1:NRetmtZZRZ0L1OXri4rOUyjk5CrA0q8jvQelm+PeulU=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 URL_PREFIX=https://github.com/filswan/go-swan-client/releases/download
-BINARY_NAME=swan-client-2.0.0-rc1-linux-amd64
-TAG_NAME=v2.0.0-rc1
+BINARY_NAME=swan-client-2.0.0-linux-amd64
+TAG_NAME=v2.0.0
 
 wget --no-check-certificate ${URL_PREFIX}/${TAG_NAME}/${BINARY_NAME}
 wget --no-check-certificate ${URL_PREFIX}/${TAG_NAME}/config.toml.example

--- a/main.go
+++ b/main.go
@@ -366,13 +366,13 @@ var generateCarCmd = &cli.Command{
 		&cli.Int64Flag{
 			Name:    "slice-size",
 			Aliases: []string{"size"},
-			Usage:   "GiB of each piece (default: 16GiB)",
+			Usage:   "bytes of each piece",
 			Value:   17179869184,
 		},
 		&cli.BoolFlag{
 			Name:  "parent-path",
-			Usage: "specify graph parent path",
-			Value: false,
+			Usage: "generate CAR file based on whole folder",
+			Value: true,
 		},
 	},
 	Action: func(ctx *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -520,7 +520,7 @@ var calculateCmd = &cli.Command{
 
 var rpcApiCmd = &cli.Command{
 	Name:      "rpc-api",
-	Usage:     "rpc-api proxy client of public chain",
+	Usage:     "RPC api proxy client of public chain",
 	ArgsUsage: "[inputPath]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -1,248 +1,509 @@
 package main
 
 import (
-	"flag"
 	"fmt"
+	big2 "github.com/filecoin-project/go-state-types/big"
+	"github.com/filswan/go-swan-client/command"
+	"github.com/filswan/go-swan-lib/logs"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+	"math/big"
 	"os"
 	"strings"
-
-	"github.com/filswan/go-swan-client/command"
-
-	"github.com/filswan/go-swan-lib/logs"
 )
 
 func main() {
-	execSubCmd()
-	//test.Test()
+	app := &cli.App{
+		Name:                 "swan-client",
+		Usage:                "A PiB level data onboarding tool for Filecoin Network",
+		Version:              command.VERSION,
+		EnableBashCompletion: true,
+		After: func(context *cli.Context) error {
+			if r := recover(); r != nil {
+				panic(r)
+			}
+			return nil
+		},
+		Commands:        []*cli.Command{toolsCmd, uploadCmd, taskCmd, dealCmd, autoCmd, calculateCmd},
+		HideHelpCommand: true,
+	}
+	if err := app.Run(os.Args); err != nil {
+		var phe *PrintHelpErr
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n\n", err)
+		if xerrors.As(err, &phe) {
+			_ = cli.ShowCommandHelp(phe.Ctx, phe.Ctx.Command.Name)
+		}
+		os.Exit(1)
+	}
 }
 
-func execSubCmd() error {
-	if len(os.Args) < 2 {
-		logs.GetLogger().Fatal("Sub command is required.")
-	}
-
-	var err error = nil
-	subCmd := os.Args[1]
-	switch subCmd {
-	case command.CMD_CAR, command.CMD_GOCAR, command.CMD_IPFSCAR, command.CMD_IPFSCMDCAR:
-		err = createCarFile(subCmd)
-	case command.CMD_UPLOAD:
-		err = uploadFile()
-	case command.CMD_TASK:
-		err = createTask()
-	case command.CMD_DEAL:
-		err = sendDeal()
-	case command.CMD_AUTO:
-		err = sendAutoBidDeal()
-	case command.CMD_VERSION:
-		err = printVersion()
-	default:
-		err = fmt.Errorf("sub command should be: car|gocar|upload|task|deal|auto|version")
-		logs.GetLogger().Error(err)
-	}
-
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	return nil
+var uploadCmd = &cli.Command{
+	Name:      "upload",
+	Usage:     "Upload CAR file to ipfs server",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "input-dir",
+			Aliases: []string{"i"},
+			Usage:   "directory where source files are in.",
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		inputDir := ctx.String("input-dir")
+		if inputDir == "" {
+			return errors.New("input-dir is required")
+		}
+		_, err := command.UploadCarFilesByConfig(inputDir)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
 }
 
-func createCarFile(subCmd string) error {
-	cmd := flag.NewFlagSet(subCmd, flag.ExitOnError)
+var taskCmd = &cli.Command{
+	Name:  "task",
+	Usage: "Send task to swan",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "name",
+			Usage: "task name",
+		},
+		&cli.StringFlag{
+			Name:    "input-dir",
+			Aliases: []string{"i"},
+			Usage:   "absolute path where the json or csv format source files",
+		},
+		&cli.StringFlag{
+			Name:    "out-dir",
+			Aliases: []string{"o"},
+			Usage:   "directory where target files will in",
+			Value:   "/tmp/tasks",
+		},
+		&cli.BoolFlag{
+			Name:  "auto-bid",
+			Usage: "send the auto-bid task",
+			Value: false,
+		},
+		&cli.BoolFlag{
+			Name:  "manual-bid",
+			Usage: "send the manual-bid task",
+			Value: false,
+		},
+		&cli.StringFlag{
+			Name:  "miners",
+			Usage: "minerID is required when send private task (pass comma separated array of minerIDs)",
+		},
+		&cli.StringFlag{
+			Name:  "dataset",
+			Usage: "curated dataset",
+		},
+		&cli.StringFlag{
+			Name:    "description",
+			Aliases: []string{"d"},
+			Usage:   "task description",
+		},
+		&cli.IntFlag{
+			Name:    "max-copy-number",
+			Aliases: []string{"max"},
+			Usage:   "max copy numbers when send auto-bid or manual-bid task",
+			Value:   1,
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		inputDir := ctx.String("input-dir")
+		if inputDir == "" {
+			return errors.New("input-dir is required")
+		}
+		if !strings.HasSuffix(inputDir, "csv") && !strings.HasSuffix(inputDir, "json") {
+			return errors.New("inputDir must be json or csv format file")
+		}
+		logs.GetLogger().Info("your input source file as: ", inputDir)
 
-	inputDir := cmd.String("input-dir", "", "Directory where source file(s) is(are) in.")
-	outputDir := cmd.String("out-dir", "", "Directory where car file(s) will be generated.")
+		auto := ctx.Bool("auto-bid")
+		manual := ctx.Bool("manual-bid")
+		minerId := ctx.String("miners")
 
-	err := cmd.Parse(os.Args[2:])
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
+		if auto && minerId != "" {
+			return errors.New("miners need not to set when auto value is true")
+		}
 
-	if !cmd.Parsed() {
-		err = fmt.Errorf("sub command parse failed")
-		logs.GetLogger().Error(err)
-		return err
-	}
+		if manual && minerId != "" {
+			return errors.New("miners need not to set when manual value is true")
+		}
 
-	if inputDir == nil || len(*inputDir) == 0 {
-		err = fmt.Errorf("input-dir is required")
-		logs.GetLogger().Error(err)
-		return err
-	}
+		if !auto && !manual && minerId == "" {
+			return errors.New("only one argument can be set among auto-bid, manual-bid and miners")
+		}
 
-	switch subCmd {
-	case command.CMD_CAR:
-		_, err = command.CreateCarFilesByConfig(*inputDir, outputDir)
-	case command.CMD_GOCAR:
-		_, err = command.CreateGoCarFilesByConfig(*inputDir, outputDir)
-	case command.CMD_IPFSCAR:
-		_, err = command.CreateIpfsCarFilesByConfig(*inputDir, outputDir)
-	case command.CMD_IPFSCMDCAR:
-		_, err = command.CreateIpfsCmdCarFilesByConfig(*inputDir, outputDir)
-	default:
-		err = fmt.Errorf("unknown sub command:%s", subCmd)
-	}
+		if auto && manual {
+			return errors.New("auto-bid and manual-bid cannot be set at the same time")
+		}
 
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
+		outputDir := ctx.String("out-dir")
+		_, fileDesc, _, total, err := command.CreateTaskByConfig(inputDir, &outputDir, ctx.String("name"), minerId,
+			ctx.String("dataset"), ctx.String("description"), auto, manual, ctx.Int("max-copy-number"))
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
 
-	return nil
+		if auto {
+			taskId := fileDesc[0].Uuid
+			exitCh := make(chan interface{})
+			go func() {
+				defer func() {
+					exitCh <- struct{}{}
+				}()
+				command.GetCmdAutoDeal(&outputDir).SendAutoBidDealsBySwanClientSourceId(inputDir, taskId, total)
+			}()
+			<-exitCh
+		}
+		return nil
+	},
 }
 
-func uploadFile() error {
-	cmd := flag.NewFlagSet(command.CMD_UPLOAD, flag.ExitOnError)
+var dealCmd = &cli.Command{
+	Name:  "deal",
+	Usage: "Send manual-bid deal",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "csv",
+			Usage: "the CSV file path of deal metadata",
+		},
+		&cli.StringFlag{
+			Name:  "json",
+			Usage: "the JSON file path of deal metadata",
+		},
+		&cli.StringFlag{
+			Name:    "out-dir",
+			Aliases: []string{"o"},
+			Usage:   "directory where target files will in",
+			Value:   "/tmp/tasks",
+		},
+		&cli.StringFlag{
+			Name:  "miners",
+			Usage: "minerID is required when send manual-bid task (pass comma separated array of minerIDs)",
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		metadataJsonPath := ctx.String("json")
+		metadataCsvPath := ctx.String("csv")
 
-	inputDir := cmd.String("input-dir", "", "Directory where source files are in.")
+		if len(metadataJsonPath) == 0 && len(metadataCsvPath) == 0 {
+			return errors.New("at least one argument can be set between csv and json")
+		}
 
-	err := cmd.Parse(os.Args[2:])
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
+		if len(metadataJsonPath) > 0 && len(metadataCsvPath) > 0 {
+			return errors.New("metadata file path is required, it cannot contain csv file path or json file path at the same time")
+		}
 
-	if !cmd.Parsed() {
-		err := fmt.Errorf("sub command parse failed")
-		logs.GetLogger().Error(err)
-		return err
-	}
+		if len(metadataJsonPath) > 0 {
+			logs.GetLogger().Info("Metadata json file:", metadataJsonPath)
+		}
+		if len(metadataCsvPath) > 0 {
+			logs.GetLogger().Info("Metadata csv file:", metadataCsvPath)
+		}
+		minerIds := ctx.String("miners")
+		if minerIds == "" {
+			return errors.New("miners is required")
+		}
 
-	if inputDir == nil || len(*inputDir) == 0 {
-		err := fmt.Errorf("input-dir is required")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	_, err = command.UploadCarFilesByConfig(*inputDir)
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	return nil
+		_, err := command.SendDealsByConfig(ctx.String("out-dir"), minerIds, metadataJsonPath, metadataCsvPath)
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
 }
 
-func createTask() error {
-	cmd := flag.NewFlagSet(command.CMD_TASK, flag.ExitOnError)
-
-	taskName := cmd.String("name", "", "Directory where source files are in.")
-	inputDir := cmd.String("input-dir", "", "Absolute path where the json or csv format source files.")
-	outputDir := cmd.String("out-dir", "", "Directory where target files will in.")
-	minerFid := cmd.String("miner", "", "Target miner fid")
-	dataset := cmd.String("dataset", "", "Curated dataset.")
-	description := cmd.String("description", "", "Task description.")
-
-	err := cmd.Parse(os.Args[2:])
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if !cmd.Parsed() {
-		err = fmt.Errorf("sub command parse failed")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if inputDir == nil || len(*inputDir) == 0 {
-		err = fmt.Errorf("input-dir is required")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if !strings.HasSuffix(*inputDir, "csv") && !strings.HasSuffix(*inputDir, "json") {
-		err := fmt.Errorf("inputDir must be json or csv format file")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	logs.GetLogger().Info("your input source file as: ", *inputDir)
-
-	_, _, _, err = command.CreateTaskByConfig(*inputDir, outputDir, *taskName, *minerFid, *dataset, *description)
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	return nil
+var autoCmd = &cli.Command{
+	Name:      "auto",
+	Usage:     "Auto send bid deal",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "out-dir",
+			Aliases: []string{"o"},
+			Usage:   "directory where target files will in.",
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		err := command.SendAutoBidDealsLoopByConfig(ctx.String("out-dir"))
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
+	Hidden: true,
 }
 
-func sendDeal() error {
-	cmd := flag.NewFlagSet(command.CMD_DEAL, flag.ExitOnError)
-
-	metadataJsonPath := cmd.String("json", "", "The JSON file path of deal metadata.")
-	metadataCsvPath := cmd.String("csv", "", "The CSV file path of deal metadata.")
-	outputDir := cmd.String("out-dir", "", "Directory where target files will in.")
-	minerFid := cmd.String("miner", "", "Target miner fid")
-
-	err := cmd.Parse(os.Args[2:])
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if !cmd.Parsed() {
-		err := fmt.Errorf("sub command parse failed")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if (metadataJsonPath == nil || len(*metadataJsonPath) == 0) && (metadataCsvPath == nil || len(*metadataCsvPath) == 0) {
-		err := fmt.Errorf("both metadataJsonPath and metadataCsvPath is nil")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if len(*metadataJsonPath) > 0 && len(*metadataCsvPath) > 0 {
-		err := fmt.Errorf("metadata file path is required, it cannot contain csv file path  or json file path  at the same time")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if len(*metadataJsonPath) > 0 {
-		logs.GetLogger().Info("Metadata json file:", *metadataJsonPath)
-	}
-	if len(*metadataCsvPath) > 0 {
-		logs.GetLogger().Info("Metadata csv file:", *metadataCsvPath)
-	}
-
-	logs.GetLogger().Info("Output dir:", *outputDir)
-
-	_, err = command.SendDealsByConfig(*outputDir, *minerFid, *metadataJsonPath, *metadataCsvPath)
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	return nil
+var inPutFlag = cli.StringFlag{
+	Name:    "input-dir",
+	Aliases: []string{"i"},
+	Usage:   "directory where source file(s) is(are) in.",
+}
+var importFlag = cli.BoolFlag{
+	Name:  "import",
+	Usage: "whether to import CAR file to lotus",
+	Value: true,
 }
 
-func sendAutoBidDeal() error {
-	cmd := flag.NewFlagSet(command.CMD_DEAL, flag.ExitOnError)
-
-	outputDir := cmd.String("out-dir", "", "Directory where target files will in.")
-
-	err := cmd.Parse(os.Args[2:])
-	if err != nil {
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	if !cmd.Parsed() {
-		err := fmt.Errorf("sub command parse failed")
-		logs.GetLogger().Error(err)
-		return err
-	}
-
-	command.SendAutoBidDealsLoopByConfig(*outputDir)
-	return nil
+var outPutFlag = cli.StringFlag{
+	Name:    "out-dir",
+	Aliases: []string{"o"},
+	Usage:   "directory where CAR file(s) will be generated.",
+	Value:   "/tmp/tasks",
 }
 
-func printVersion() error {
-	println(command.VERSION)
-	return nil
+//做完了
+var lotusCarCmd = &cli.Command{
+	Name:      "lotus",
+	Usage:     "Use lotus api to generate CAR file",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&inPutFlag,
+		&outPutFlag,
+		&importFlag,
+	},
+	Action: func(ctx *cli.Context) error {
+		inputDir := ctx.String("input-dir")
+		if inputDir == "" {
+			return errors.New("input-dir is required")
+		}
+		outputDir := ctx.String("out-dir")
+		if _, err := command.CreateCarFilesByConfig(inputDir, &outputDir, ctx.Bool("import")); err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
+}
+
+var splitCarCmd = &cli.Command{
+	Name:            "graphsplit",
+	Usage:           "Use go-graphsplit tools",
+	Subcommands:     []*cli.Command{generateCarCmd, carRestoreCmd},
+	HideHelpCommand: true,
+}
+
+var generateCarCmd = &cli.Command{
+	Name:      "car",
+	Usage:     "Generate CAR files of the specified size",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&inPutFlag,
+		&outPutFlag,
+		&importFlag,
+		&cli.IntFlag{
+			Name:  "parallel",
+			Usage: "number goroutines run when building ipld nodes",
+			Value: 5,
+		},
+		&cli.Int64Flag{
+			Name:    "slice-size",
+			Aliases: []string{"size"},
+			Usage:   "GiB of each piece (default: 16GiB)",
+			Value:   17179869184,
+		},
+		&cli.BoolFlag{
+			Name:  "parent-path",
+			Usage: "specify graph parent path",
+			Value: false,
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		inputDir := ctx.String("input-dir")
+		if inputDir == "" {
+			return errors.New("input-dir is required")
+		}
+		outputDir := ctx.String("out-dir")
+		if _, err := command.CreateGoCarFilesByConfig(inputDir, &outputDir, ctx.Int("parallel"), ctx.Int64("slice-size"), ctx.Bool("parent-path"), ctx.Bool("import")); err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
+}
+
+var carRestoreCmd = &cli.Command{
+	Name:      "restore",
+	Usage:     "Restore files from CAR files",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&outPutFlag,
+		&cli.StringFlag{
+			Name:     "input-dir",
+			Aliases:  []string{"i"},
+			Usage:    "specify source CAR path, directory or file",
+			Required: true,
+		},
+		&cli.Int64Flag{
+			Name:  "parallel",
+			Usage: "number goroutines run when building ipld nodes",
+			Value: 5,
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		inputDir := ctx.String("input-dir")
+		if inputDir == "" {
+			return errors.New("input-dir is required")
+		}
+		outputDir := ctx.String("out-dir")
+		if err := command.RestoreCarFilesByConfig(inputDir, &outputDir, ctx.Int("parallel")); err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
+}
+
+var ipfsCarCmd = &cli.Command{
+	Name:      "ipfs",
+	Usage:     "Use ipfs api to generate CAR file",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&inPutFlag,
+		&outPutFlag,
+		&importFlag,
+	},
+	Action: func(ctx *cli.Context) error {
+		inputDir := ctx.String("input-dir")
+		if inputDir == "" {
+			return errors.New("input-dir is required")
+		}
+		outputDir := ctx.String("out-dir")
+		if _, err := command.CreateIpfsCarFilesByConfig(inputDir, &outputDir, ctx.Bool("import")); err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
+}
+
+var toolsCmd = &cli.Command{
+	Name:            "generate-car",
+	Usage:           "Generate CAR files from a file or directory",
+	Subcommands:     []*cli.Command{splitCarCmd, lotusCarCmd, ipfsCarCmd, ipfsCmdCarCmd},
+	HideHelpCommand: true,
+}
+
+var ipfsCmdCarCmd = &cli.Command{
+	Name:      "ipfs-car",
+	Usage:     "use the ipfs-car command to generate the CAR file",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&inPutFlag,
+		&outPutFlag,
+		&importFlag,
+	},
+	Action: func(ctx *cli.Context) error {
+		inputDir := ctx.String("input-dir")
+		if inputDir == "" {
+			return errors.New("input-dir is required")
+		}
+		outputDir := ctx.String("out-dir")
+		if _, err := command.CreateIpfsCmdCarFilesByConfig(inputDir, &outputDir, ctx.Bool("import")); err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		return nil
+	},
+}
+
+var calculateCmd = &cli.Command{
+	Name:      "commP",
+	Usage:     "Calculate the dataCid, pieceCid, pieceSize of the CAR file",
+	ArgsUsage: "[inputPath]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "car-path",
+			Usage: "absolute path to the car file",
+		},
+		&cli.BoolFlag{
+			Name:   "data-cid",
+			Usage:  "whether to generate the dataCid flag",
+			Value:  true,
+			Hidden: true,
+		},
+		&cli.BoolFlag{
+			Name:  "piece-cid",
+			Usage: "whether to generate the pieceCid flag",
+			Value: false,
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		carPath := ctx.String("car-path")
+		if carPath == "" {
+			return errors.New("car-path is required")
+		}
+		dataCid, pieceCid, pieceSize, err := command.CalculateValueByCarFile(carPath, ctx.Bool("data-cid"), ctx.Bool("piece-cid"))
+		if err != nil {
+			logs.GetLogger().Error(err)
+			return err
+		}
+		fmt.Println("CarFileName: ", carPath)
+		if ctx.Bool("data-cid") {
+			fmt.Println("DataCID: ", dataCid)
+		}
+		if ctx.Bool("piece-cid") {
+			fmt.Println("PieceCID: ", pieceCid)
+			fmt.Println("PieceSize: ", SizeStr(NewInt(pieceSize)))
+			fmt.Println("Piece size in bytes: ", NewInt(pieceSize))
+		}
+		return nil
+	},
+}
+
+type BigInt = big2.Int
+
+func NewInt(i uint64) BigInt {
+	return BigInt{Int: big.NewInt(0).SetUint64(i)}
+}
+
+var byteSizeUnits = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB"}
+
+func SizeStr(bi big2.Int) string {
+	r := new(big.Rat).SetInt(bi.Int)
+	den := big.NewRat(1, 1024)
+
+	var i int
+	for f, _ := r.Float64(); f >= 1024 && i+1 < len(byteSizeUnits); f, _ = r.Float64() {
+		i++
+		r = r.Mul(r, den)
+	}
+
+	f, _ := r.Float64()
+	return fmt.Sprintf("%.4g %s", f, byteSizeUnits[i])
+}
+
+type PrintHelpErr struct {
+	Err error
+	Ctx *cli.Context
+}
+
+func (e *PrintHelpErr) Error() string {
+	return e.Err.Error()
+}
+
+func (e *PrintHelpErr) Unwrap() error {
+	return e.Err
+}
+
+func (e *PrintHelpErr) Is(o error) bool {
+	_, ok := o.(*PrintHelpErr)
+	return ok
+}
+
+func ShowHelp(cctx *cli.Context, err error) error {
+	return &PrintHelpErr{Err: err, Ctx: cctx}
+}
+
+func WithCategory(cat string, cmd *cli.Command) *cli.Command {
+	cmd.Category = strings.ToUpper(cat)
+	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -320,7 +320,6 @@ var outPutFlag = cli.StringFlag{
 	Value:   "/tmp/tasks",
 }
 
-//做完了
 var lotusCarCmd = &cli.Command{
 	Name:      "lotus",
 	Usage:     "Use lotus api to generate CAR file",


### PR DESCRIPTION
**New Features**
- Task: auto-bid task for all clients([filswan/go-swan-client#170](https://github.com/filswan/go-swan-client/pull/170))

 - RPC: use the rpc command to query chain info from the Pocket rpclist, `./swan-client rpc` or `./swan-client rpc-api`([filswan/go-swan-client#173](https://github.com/filswan/go-swan-client/pull/173))

 - RPC: deploy a free blockchain RPC service, `./swan-client daemon`, more chain rpc-api documents have been listed [here]()([filswan/go-swan-client#174](https://github.com/filswan/go-swan-client/pull/174))

- CMD: UX improvements for all users, try `./swan-client -h`([filswan/go-swan-client#170](https://github.com/filswan/go-swan-client/pull/170)), 

- Document: new command document has been created([filswan/go-swan-client#175](https://github.com/filswan/go-swan-client/pull/175))
