### PR TITLE
docs: Fix typo in task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ OPTIONS:
 
 You can create manual-bid tasks on the swan platform. And each storage provider can apply this task from swan platform. After that, you can send deals to the storage providers.
 
-**(1) Create manulal-bid task:**
+**(1) Create manual-bid task:**
 
 ```shell
 swan-client task --input-dir [json_or_csv_absolute_path] --out-dir [output_files_dir] --manual-bid true --max-copy-number 5


### PR DESCRIPTION
Hey, I noticed a typo in the task name: **"manulal-bid"** → **"manual-bid"**.

<img width="322" alt="Снимок экрана 2025-02-03 в 15 56 19" src="https://github.com/user-attachments/assets/bcff9462-99cd-4668-8dad-b7208d42ddfb" />

Fixed it to keep everything clean and consistent.